### PR TITLE
Adding folder of scripts helpful for common actions on Biowulf

### DIFF
--- a/biowulf_helper_scripts/cancel_snakemake_jobs.sh
+++ b/biowulf_helper_scripts/cancel_snakemake_jobs.sh
@@ -1,0 +1,23 @@
+##  Usage: ./cancel_snakemake_jobs.sh [ SNAKEMAKE_LOG_FILE ]
+## 
+##  This script will find all Slurm IDs in a snakemake log file
+##   and issue 'scancel' to cancel them
+
+
+if [ $# -eq 0 ]
+then
+   snakeout_file="Reports/snakemake.log"
+else
+   snakeout_file=$1
+fi
+
+JOB_IDS=( $(grep "external jobid" $snakeout_file | sed "s/^.*jobid '\(.*\)'.$/\1/") )
+
+echo “Found ${#JOB_IDS[@]} SLURM IDs… Cancelling them…”
+for id in ${JOB_IDS[@]}
+do
+   #echo "scancel $id"
+   scancel $id
+done
+
+echo “Done.”

--- a/biowulf_helper_scripts/create_hpc_link.sh
+++ b/biowulf_helper_scripts/create_hpc_link.sh
@@ -1,0 +1,6 @@
+##  Usage: ./create_hpc_link.sh
+## 
+##  This script will print the HPC Datashare URL for accessing files in /data/CCBR/datashare
+##   for all files in the current directory
+
+ls $(pwd)/* | sed -e 's/\/data\/CCBR\/datashare/https:\/\/hpc.nih.gov\/~CCBR/'

--- a/biowulf_helper_scripts/get_slurm_file_with_error.sh
+++ b/biowulf_helper_scripts/get_slurm_file_with_error.sh
@@ -1,0 +1,61 @@
+##  Usage: ./get_slurm_file_with_error.sh [ SNAKEMAKE_LOG_FILE ]
+## 
+##  This script tries to find the first failed job and returns the slurm output file
+##   that hopefully contains the error.  This was written for troubleshooting CCBR 
+##   Pipeliner, but should basically work for any Snakemake job on Biowulf you provide
+##   as an argument
+
+## Specifically, it does this:
+## 1. Find the first occurence of "Job failed" in the snakemake log file
+## 2. Find the job id/rule name associated with it (usually occurs 3/4 lines before)
+## 3. Find the Slurm ("external") ID of that job from when it was submitted
+## 4. Find the slurm output file with that ID
+## 
+## The analyst can then go through the slurm file to find/evaluate the error
+
+## One liner version:
+## grep -B 5 -m1 "Job failed" Reports/snakemake.log | grep "jobid: " | grep "job $(sed 's/^.*jobid: \(.*\)$/\1/')" Reports/snakemake.log |  slurm-$(sed "s/^.*jobid '\(.*\)'\.$/\1/").out
+
+if [ $# -eq 0 ]
+then
+   SNAKEMAKE_LOG=Reports/snakemake.log
+else
+   SNAKEMAKE_LOG=$1
+fi
+
+jobid=$(grep -B 5 -m1 "Job failed" $SNAKEMAKE_LOG | grep "jobid: " | sed 's/^.*jobid: \(.*\)$/\1/')
+rulename=$(grep -B 5 -m1 "Job failed" $SNAKEMAKE_LOG | grep "Error in rule " | sed 's/^.*Error in rule \(.*\):$/\1/')
+
+if [ "$jobid" = "" ]
+then
+   echo ""
+   echo "Couldn't find any explicit failures."
+   echo ""
+else
+   
+   slurmids=($(grep "job $jobid " $SNAKEMAKE_LOG | sed "s/^.*jobid '\(.*\)'\.$/\1/"))
+   echo -e 'Rule Name\tSlurm ID(s)'
+   echo -e $rulename'\t'$(IFS=, ; echo "${slurmids[*]}")
+   echo ""
+   
+   if [ ${#slurmids[@]} -gt 0 ]; then
+      echo "Slurm output files are listed below:"
+      for slurmid in "${slurmids[@]}"; do
+         #echo $slurmid
+         errorfile="slurm-$slurmid.out"
+         ## I'm not doing using find because that might take forever
+         ##   when there's lots of files (like for large datasets)
+         if [ ! -e $errorfile ]
+         then
+            errorfile=slurmfiles/$errorfile
+            if [ ! -e $errorfile ]
+            then
+               echo "Hmm... can't find the slurm error file..."
+            fi
+         fi
+         
+         ls -lh $errorfile
+      done
+   fi
+fi	
+ 

--- a/biowulf_helper_scripts/make_labels_for_pipeliner.sh
+++ b/biowulf_helper_scripts/make_labels_for_pipeliner.sh
@@ -1,0 +1,11 @@
+##  Usage: ./make_labels_for_pipeliner.sh
+## 
+##  This script will look for *fastq.gz files in the current directory and
+##   make a 'labels.txt' file for pipeliner when the FASTQs do not conform
+##   to pipeliner's nomenclature (i.e. *_R1_001.fastq.gz instead of *.R1.fastq.gz)
+
+ls -1 *.fastq.gz > oldnames.txt
+## This sed command will remove the '_S###_' suffix and skip '_L001_' if there
+ls *.fastq.gz | sed -re 's/_S[0-9]{1,3}_.*(R[1,2])_001/.\1/g' > newnames.txt
+paste oldnames.txt newnames.txt > labels.txt
+rm oldnames.txt newnames.txt


### PR DESCRIPTION
Added 4 scripts:

- cancel_snakemake_jobs.sh : cancels all submitted jobs found in a Snakemake log file
- create_hpc_link.sh : print URLs for files in a datashare directory (/data/CCBR/datashare)
- get_slurm_file_with_error.sh : identifies first failure in Snakemake log file and associated Slurm log file
- make_labels_for_pipeliner.sh : creates 'labels.txt' file for Pipeliner when fastqs don't match *.R1.fastq.gz nomenclature
