### PR TITLE
fix: don't add extra newline to command stdout/stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Tools development version
 
+- fix: don't add extra newline to command stdout/stderr for `shell_run()` and `exec_in_context()`. (#10, @kelly-sovacool)
+
 ## Tools 0.1.0
 
 The Tools repository is now restructured as a Python package.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- README.md is generated from README.qmd. Please edit that file -->
-
 # CCBR Tools
+
+<!-- README.md is generated from README.qmd. Please edit that file -->
 
 Utilities for CCBR Bioinformatics Software
 
@@ -14,19 +14,19 @@ Utilities for CCBR Bioinformatics Software
 On biowulf you can access the latest release of `ccbr_tools` by loading
 the ccbrpipeliner module:
 
-```sh
+``` sh
 module load ccbrpipeliner
 ```
 
 Outside of biowulf, you can install the package with pip:
 
-```sh
+``` sh
 pip install git+https://github.com/CCBR/Tools
 ```
 
 Or specify a specific tagged version or branch:
 
-```sh
+``` sh
 pip install git+https://github.com/CCBR/Tools@v0.1.0
 ```
 
@@ -34,7 +34,7 @@ pip install git+https://github.com/CCBR/Tools@v0.1.0
 
 ### CLI
 
-```sh
+``` sh
 ccbr_tools --help
 ```
 
@@ -63,7 +63,7 @@ ccbr_tools --help
 
 ### Python
 
-```python
+``` python
 import ccbr_tools.pkg_util
 print(ccbr_tools.pkg_util.get_version())
 ```

--- a/src/ccbr_tools/shell.py
+++ b/src/ccbr_tools/shell.py
@@ -31,7 +31,10 @@ def shell_run(command_str, capture_output=True, check=True, shell=True, text=Tru
         command_str, capture_output=capture_output, shell=shell, text=text, check=check
     )
     if capture_output:
-        return concat_newline(out.stdout, out.stderr)
+        return_val = concat_newline(out.stdout, out.stderr)
+    else:
+        return_val = ""
+    return return_val
 
 
 def exec_in_context(func: callable, *args: str, **kwargs: str):

--- a/src/ccbr_tools/shell.py
+++ b/src/ccbr_tools/shell.py
@@ -31,7 +31,7 @@ def shell_run(command_str, capture_output=True, check=True, shell=True, text=Tru
         command_str, capture_output=capture_output, shell=shell, text=text, check=check
     )
     if capture_output:
-        return "\n".join([out.stdout, out.stderr])
+        return concat_newline(out.stdout, out.stderr)
 
 
 def exec_in_context(func: callable, *args: str, **kwargs: str):
@@ -42,6 +42,7 @@ def exec_in_context(func: callable, *args: str, **kwargs: str):
         func (func): The function to be executed.
         *args: Variable length argument list to be passed to the function.
         **kwargs: Arbitrary keyword arguments to be passed to the function.
+
     Returns:
         str: The combined output from both stdout and stderr.
     """
@@ -50,5 +51,18 @@ def exec_in_context(func: callable, *args: str, **kwargs: str):
         contextlib.redirect_stderr(io.StringIO()) as err_f,
     ):
         func(*args, **kwargs)
-        out_combined = "\n".join([out_f.getvalue(), err_f.getvalue()])
+        out_combined = concat_newline(out_f.getvalue(), err_f.getvalue())
     return out_combined
+
+
+def concat_newline(*args: str):
+    """
+    Concatenates strings with a newline character between non-empty arguments
+
+    Args:
+        *args: Variable length argument list of strings to be concatenated.
+
+    Returns:
+        str: The concatenated string with newline characters between each non-empty argument.
+    """
+    return "\n".join([arg for arg in args if arg])

--- a/tests/test_hpc.py
+++ b/tests/test_hpc.py
@@ -25,5 +25,5 @@ def test_hpc_frce():
 
 
 def test_hpc_none():
-    hpc = get_hpc(debug="")
+    hpc = get_hpc(debug=" ")
     assert not any([hpc, hpc.name, *hpc.modules.values(), hpc.singularity_sif_dir])

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,5 +1,18 @@
-from ccbr_tools.shell import exec_in_context
+from ccbr_tools.shell import shell_run, exec_in_context, concat_newline
 
 
 def test_exec():
-    assert exec_in_context(print, "hello", "world") == "hello world\n\n"
+    assert exec_in_context(print, "hello", "world") == "hello world\n"
+
+
+def test_shell_run():
+    assert shell_run("echo hello world") == "hello world\n"
+
+
+def test_concat_newline():
+    assert all(
+        [
+            concat_newline("hello", "world") == "hello\nworld",
+            concat_newline("goodbye", "") == "goodbye",
+        ]
+    )


### PR DESCRIPTION
## Changes

shell_run() and exec_in_context() were adding extra newlines to command output, which messed up other functions that used them

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
