### PR TITLE
fix: use datetime import correctly for _get_file_mtime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Tools development version
 
 - use major & minor version for docs website subdirectories. (#15, @kelly-sovacool)
-- Fig bug where `nextflow.run()` did not import the correct HPC modules. (#20, @kelly-sovacool)
+- fig bug where `nextflow.run()` did not import the correct HPC modules. (#20, @kelly-sovacool)
+- fix bug in `_get_file_mtime()`. (#21, @kelly-sovacool)
 
 ## Tools 0.1.1
 

--- a/src/ccbr_tools/pipeline/util.py
+++ b/src/ccbr_tools/pipeline/util.py
@@ -353,7 +353,7 @@ def check_python_version(MIN_PYTHON=(3, 11)):
 
 
 def _get_file_mtime(f):
-    timestamp = datetime.fromtimestamp(os.path.getmtime(os.path.abspath(f)))
+    timestamp = datetime.datetime.fromtimestamp(os.path.getmtime(os.path.abspath(f)))
     mtime = timestamp.strftime("%y%m%d%H%M%S")
     return mtime
 

--- a/tests/test_pipeline_util.py
+++ b/tests/test_pipeline_util.py
@@ -1,4 +1,4 @@
-from ccbr_tools.pipeline.util import get_tmp_dir
+from ccbr_tools.pipeline.util import get_tmp_dir, _get_file_mtime
 
 
 def test_tmp_dir():
@@ -9,3 +9,8 @@ def test_tmp_dir():
             get_tmp_dir("", "./out", hpc="none") == None,
         ]
     )
+
+
+def test_get_mtime():
+    mtime = _get_file_mtime("tests/data/file.txt")
+    assert all([len(mtime) == 12, mtime.isdigit()])


### PR DESCRIPTION
## Changes

this function was moved from RENEE but the import statement was not updated

it is only used when rerunning pipelines, so the error wasn't caught until now

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
