### PR TITLE
feat: allow relaxed version with only major & minor components

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Tools development version
 
-- Allow relaxed version with only major and minor components in `match_semver()`. (#49, @kelly-sovacool)
+- Allow relaxed version with only major and minor components in `match_semver()` with `strict_semver=False`. (#49, @kelly-sovacool)
 
 ## Tools 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Tools development version
 
+- Allow relaxed version with only major and minor components in `match_semver()`. (#49, @kelly-sovacool)
+
 ## Tools 0.2.4
 
 - Fix `ccbr_tools.pipeline.nextflow.run`: (#46, @kelly-sovacool)

--- a/src/ccbr_tools/versions.py
+++ b/src/ccbr_tools/versions.py
@@ -26,11 +26,7 @@ def get_current_hash():
     return shell_run("git rev-parse HEAD").strip()
 
 
-def match_semver(
-    version_str,
-    with_leading_v=False,
-    pattern=r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?",
-):
+def match_semver(version_str, with_leading_v=False, strict_semver=True, pattern=None):
     """
     Match a version string against the semantic versioning pattern.
 
@@ -39,8 +35,8 @@ def match_semver(
     Args:
         version_str (str): The version string to match against the semantic versioning pattern.
         with_leading_v (bool): If True, the version string is expected to start with a leading 'v'.
-        re.Match or None: The match object if the version string matches the semantic versioning pattern, otherwise None.
-
+        strict_semver (bool): If True, the version string must match the full semantic versioning pattern. Otherwise, a relaxed format with only the major and minor components is allowed.
+        pattern (str, optional): A custom regex pattern to match against the version string. If None, the default semantic versioning pattern is used.
     Returns:
         re.Match or None
             The match object if the version string matches the semantic versioning pattern, otherwise None.
@@ -56,19 +52,20 @@ def match_semver(
         >>> match_semver("invalid_version")
         None
     """
+    if not pattern:
+        pattern = (
+            r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+            if strict_semver
+            else r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
+        )
+
     if with_leading_v:
         pattern = f"v{pattern}"
     semver_match = re.match(pattern, version_str)
-    if not semver_match:
-        # use relaxed version with only major & minor components
-        relaxed_pattern = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
-        if with_leading_v:
-            relaxed_pattern = f"v{relaxed_pattern}"
-        semver_match = re.match(relaxed_pattern, version_str)
     return semver_match
 
 
-def get_major_minor_version(version_str, with_leading_v=False):
+def get_major_minor_version(version_str, with_leading_v=False, strict_semver=True):
     """
     Extract the major and minor version from a semantic versioning string.
 
@@ -77,6 +74,7 @@ def get_major_minor_version(version_str, with_leading_v=False):
     Args:
         version_str (str): The version string to extract from.
         with_leading_v (bool): Whether to include a leading 'v' in the output.
+        strict_semver (bool): If True, the version string must match the full semantic versioning pattern. Otherwise, a relaxed format with only the major and minor components is allowed.
 
     Returns:
         str or None: The major and minor version in the format 'major.minor', or None if the version string is invalid.
@@ -91,8 +89,11 @@ def get_major_minor_version(version_str, with_leading_v=False):
         '2.1'
         >>> get_major_minor_version("invalid_version")
         None
+        >>> get_major_minor_version('3.1', strict_semver=False)
     """
-    semver_match = match_semver(version_str, with_leading_v=with_leading_v)
+    semver_match = match_semver(
+        version_str, with_leading_v=with_leading_v, strict_semver=strict_semver
+    )
     prefix = "v" if with_leading_v else ""
     return (
         f"{prefix}{semver_match.group('major')}.{semver_match.group('minor')}"

--- a/src/ccbr_tools/versions.py
+++ b/src/ccbr_tools/versions.py
@@ -26,7 +26,11 @@ def get_current_hash():
     return shell_run("git rev-parse HEAD").strip()
 
 
-def match_semver(version_str, with_leading_v=False):
+def match_semver(
+    version_str,
+    with_leading_v=False,
+    pattern=r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?",
+):
     """
     Match a version string against the semantic versioning pattern.
 
@@ -52,10 +56,16 @@ def match_semver(version_str, with_leading_v=False):
         >>> match_semver("invalid_version")
         None
     """
-    semver_pattern = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
     if with_leading_v:
-        semver_pattern = f"v{semver_pattern}"
-    return re.match(semver_pattern, version_str)
+        pattern = f"v{pattern}"
+    semver_match = re.match(pattern, version_str)
+    if not semver_match:
+        # use relaxed version with only major & minor components
+        relaxed_pattern = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
+        if with_leading_v:
+            relaxed_pattern = f"v{relaxed_pattern}"
+        semver_match = re.match(relaxed_pattern, version_str)
+    return semver_match
 
 
 def get_major_minor_version(version_str, with_leading_v=False):

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -75,6 +75,17 @@ def test_get_major_minor():
             get_major_minor_version("2.1.3-alpha") == "2.1",
             get_major_minor_version("v1.0.0", with_leading_v=True) == "v1.0",
             get_major_minor_version("invalid_version") == None,
+            get_major_minor_version("1.2.3.4.5.6") == "1.2",
+        ]
+    )
+
+
+def test_get_major_minor_nonsemantic():
+    assert all(
+        [
+            get_major_minor_version("1.0") == "1.0",
+            get_major_minor_version("v3.4", with_leading_v=True) == "v3.4",
+            get_major_minor_version("3.a") == None,
         ]
     )
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -83,9 +83,10 @@ def test_get_major_minor():
 def test_get_major_minor_nonsemantic():
     assert all(
         [
-            get_major_minor_version("1.0") == "1.0",
-            get_major_minor_version("v3.4", with_leading_v=True) == "v3.4",
-            get_major_minor_version("3.a") == None,
+            get_major_minor_version("1.0", strict_semver=False) == "1.0",
+            get_major_minor_version("v3.4", with_leading_v=True, strict_semver=False)
+            == "v3.4",
+            get_major_minor_version("3.a", strict_semver=False) == None,
         ]
     )
 


### PR DESCRIPTION
## Changes

new argument `strict_semver` in `match_semver()` and related functions to toggle enforcing strict semantic versioning or allow a relaxed version with only major & minor components

## Issues

see https://github.com/CCBR/actions/issues/71

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
