### PR TITLE
fix: use repo instead of args for get_latest_release_tag/hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Tools development version
 
+- Remove `args` and add `repo` parameter to `get_latest_release_tag()` and `get_latest_release_hash()`. (#51, @kelly-sovacool)
+
 ## Tools 0.2.4
 
 - Fix `ccbr_tools.pipeline.nextflow.run`: (#46, @kelly-sovacool)

--- a/src/ccbr_tools/versions.py
+++ b/src/ccbr_tools/versions.py
@@ -4,7 +4,10 @@ Get information from git tags, commit hashes, and GitHub releases.
 
 import json
 import re
+import warnings
+
 from .shell import shell_run
+from .pkg_util import get_url_json
 
 
 def get_current_hash():
@@ -246,7 +249,7 @@ def get_releases(limit=1, args="", json_fields="name,tagName,isLatest,publishedA
     return json.loads(releases)
 
 
-def get_latest_release_tag(args=""):
+def get_latest_release_tag(repo="CCBR/Tools"):
     """
     Get the tag name of the latest release.
 
@@ -265,6 +268,7 @@ def get_latest_release_tag(args=""):
         >>> get_latest_release_tag()
         'v1.0.0'
     """
+    args = f"--repo {repo}" if repo else ""
     releases = get_releases(limit=100, args=args)
     latest_release = next(
         (release for release in releases if release["isLatest"]), None
@@ -272,14 +276,14 @@ def get_latest_release_tag(args=""):
     return latest_release["tagName"] if latest_release else ""
 
 
-def get_latest_release_hash(args=""):
+def get_latest_release_hash(repo="CCBR/Tools"):
     """
     Get the commit hash of the latest release.
 
     Uses git rev-list to get the commit hash of the latest release tag.
 
     Args:
-        args (str, optional): Additional arguments to pass to the GitHub CLI command (default is "").
+        repo (str, optional): The GitHub repository in the format 'owner/repo'. Default: 'CCBR/Tools'
 
     Returns:
         str: The commit hash of the latest release.
@@ -294,10 +298,32 @@ def get_latest_release_hash(args=""):
         >>> get_latest_release_hash()
         'abc123def4567890abcdef1234567890abcdef12'
     """
-    tag_name = get_latest_release_tag(args=args)
-    tag_hash = ""
-    if tag_name:
-        tag_hash = shell_run(f"git rev-list -n 1 {tag_name}")
-        if "fatal: ambiguous argument" in tag_hash:
-            raise ValueError(f"Tag {tag_name} not found in repository commit history")
+    tag_name = get_latest_release_tag(repo=repo)
+    tag_hash = get_tag_hash(tag_name, repo=repo)
     return tag_hash.strip()
+
+
+def get_tag_hash(tag_name, args="", repo="CCBR/Tools"):
+    """
+    Retrieve the commit hash associated with a specific tag in a GitHub repository.
+    Args:
+        tag_name (str): The name of the tag for which the commit hash is to be retrieved.
+        repo (str, optional): The GitHub repository in the format 'owner/repo'.
+                              Defaults to 'CCBR/Tools'.
+    Returns:
+        str: The commit hash (SHA) associated with the specified tag.
+    Raises:
+        requests.exceptions.RequestException: If there is an issue with the HTTP request.
+        KeyError: If the expected data is not found in the API response.
+    """
+
+    # use gh api to retrieve the commit hash of a tag
+    try:
+        tag_info = get_url_json(
+            f"https://api.github.com/repos/{repo}/git/refs/tags/{tag_name}"
+        )
+        hash = tag_info["object"]["sha"]
+    except ConnectionError:
+        warnings.warn(f"Could not retrieve tag info for {tag_name} from {repo}.")
+        hash = ""
+    return hash

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -4,6 +4,7 @@ from ccbr_tools.versions import (
     get_releases,
     get_latest_release_tag,
     get_latest_release_hash,
+    get_tag_hash,
     match_semver,
     check_version_increments_by_one,
     get_major_minor_version,
@@ -23,7 +24,18 @@ def test_get_latest_release_hash():
     assert all(
         [
             len(get_latest_release_hash()) > 7,
-            get_latest_release_hash(args="--repo CCBR/CCBR_NextflowTemplate") == "",
+            len(get_latest_release_hash(repo="CCBR/actions")) > 7,
+            get_latest_release_hash(repo="CCBR/CCBR_NextflowTemplate") == "",
+        ]
+    )
+
+
+def test_get_tag_hash():
+    assert all(
+        [
+            len(get_tag_hash("v0.1.0")) > 7,
+            len(get_tag_hash("v0.2.0", repo="CCBR/actions")) > 7,
+            get_tag_hash("notATag", repo="CCBR/CCBR_NextflowTemplate") == "",
         ]
     )
 


### PR DESCRIPTION
## Changes

remove `args` and add `repo` for `get_latest_release_tag` and `get_latest_release_hash`

## Issues

resolves #50

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
