### PR TITLE
fix: make sure symlinks in same dir as target use rel path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Tools development version
 
+- fix `ccbr_tools install` to use relative paths for symlinks within the same directory. (#58, @kelly-sovacool)
+
 ## Tools 0.3.1
 
 - Bug fixes in `ccbr_tools install`:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ guidelines](https://CCBR.github.io/Tools/CONTRIBUTING).
 Please cite this software if you use it in a publication:
 
 > Sovacool K., Koparde V., Kuhn S., Tandon M., and Huse S. (2025). CCBR
-> Tools: Utilities for CCBR Bioinformatics Software (version v0.3.0).
+> Tools: Utilities for CCBR Bioinformatics Software (version v0.3.1).
 > DOI: 10.5281/zenodo.13377166 URL: https://ccbr.github.io/Tools/
 
 ### Bibtex entry

--- a/src/ccbr_tools/software.py
+++ b/src/ccbr_tools/software.py
@@ -143,8 +143,10 @@ CCBR_SOFTWARE = {
 
 
 SET_SYMLINK = """
+pushd {BASE_PATH}
 rm -if {MAJOR_MINOR_VERSION}
-ln -s {PATH} {MAJOR_MINOR_VERSION}"""
+ln -s {HIDDEN_VERSION} {MAJOR_MINOR_VERSION}
+popd"""
 
 INSTALL_SCRIPT = """{CONDA_ACTIVATE}
 {INSTALL}
@@ -172,8 +174,9 @@ def install(
     )
     if not tool.is_dev_version:
         script += symlink_script.format(
-            PATH=tool.path(hpc),
-            MAJOR_MINOR_VERSION=tool.base_path(hpc) / tool.major_minor,
+            BASE_PATH=tool.base_path(hpc),
+            HIDDEN_VERSION=tool.hidden_version,
+            MAJOR_MINOR_VERSION=tool.major_minor,
         )
     if dryrun:
         print(script)

--- a/tests/test_software.py
+++ b/tests/test_software.py
@@ -46,8 +46,10 @@ def test_install():
 pip install git+https://github.com/CCBR/CHAMPAGNE.git@v0.3.0 -t /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0
 chmod -R a+rX /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0
 chown -R :CCBR_Pipeliner /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0
-rm -if /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/v0.3
-ln -s /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0 /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/v0.3
+pushd /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE
+rm -if v0.3
+ln -s .v0.3.0 v0.3
+popd
 """
     )
 


### PR DESCRIPTION
## Changes

there's no need for symlinks to use an absolute path when the target is in the same directory

![image](https://github.com/user-attachments/assets/2c76c165-b6cf-47e8-9d7c-c24d07460a2a)


## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
