### PR TITLE
feat: add pipeline_path as optional spooker argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `ccbr_tools install` has new options: (#60, @kelly-sovacool)
   - `--type` to specify the type of tool to install (e.g. `PythonTool`, `BashTool`, `Snakemake`, or `Nextflow`).
   - `--hpc` (e.g. `biowulf`, `frce`) to specify the HPC environment for debugging purposes.
+- `spooker` now accepts the path to the pipeline CLI as an optional argument. (#69, @kelly-sovacool)
 
 ### Bug fixes
 

--- a/scripts/spooker
+++ b/scripts/spooker
@@ -31,6 +31,7 @@ if [[ "$#" -lt "2" ]];then
     echo "    Argument 1: pipeline outdir"
     echo "    Argument 2: pipeline name"
     echo "    Argument 3: pipeline version (optional)"
+    echo "    Argument 4: pipeline source path (optional)"
     exit 1
 fi
 
@@ -38,14 +39,17 @@ set -o pipefail
 PIPELINE_OUTDIR=$1
 PIPELINE_NAME=$2
 PIPELINE_VERSION=$3
+PIPELINE_PATH=$4
 if [ ${#PIPELINE_VERSION} -eq 0 ]; then
     PIPELINE_VERSION="UNKNOWN"
+fi
+if [ ${#PIPELINE_PATH} -eq 0 ]; then
+    PIPELINE_PATH="UNKNOWN"
 fi
 
 PIPELINE_OUTDIR_SIZE=$(du -bs $PIPELINE_OUTDIR | awk '{print $1}')
 PIPELINE_NAME_UPPER=$(echo "$PIPELINE_NAME" | tr '[:lower:]' '[:upper:]')
 PIPELINE_NAME_LOWER=$(echo "$PIPELINE_NAME" | tr '[:upper:]' '[:lower:]')
-PIPELINE_PATH=$(which $PIPELINE_NAME_LOWER) # TODO this is not guaranteed to be correct
 CCBRPIPELINER_MODULE=$(module list ccbrpipeliner 2>&1 /dev/null | grep ')' | tail -n 1 | sed 's/.*) //')
 if [[ "CCBRPIPELINER_MODULE" == "" ]];then
     CCBRPIPELINER_MODULE="UNKNOWN"

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -208,9 +208,7 @@ def get_sacct_info(job_ids):
                 records.append(record)
 
         except subprocess.CalledProcessError as err:
-            raise RuntimeError(
-                f"❌ Failed to fetch info for JobID {jobid}"
-            ).with_traceback(err.__traceback__) from err
+            warnings.warn(f"❌ Failed to fetch info for JobID {jobid}")
         except FileNotFoundError as err:
             raise RuntimeError(
                 "❌ sacct command not found. Is SLURM installed?"
@@ -315,11 +313,11 @@ def jobby(args):
         job_ids = args  # Treat all arguments as job IDs
 
     if not job_ids:
-        raise ValueError("⚠️ No job IDs to process.")
+        warnings.warn("⚠️ No job IDs to process.")
 
     records = get_sacct_info(job_ids)
     if not records:
-        raise ValueError("⚠️ No job data found.")
+        warnings.warn("⚠️ No job data found.")
 
     df = records_to_df(records)
     print(format_df(df, output_format))

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -316,11 +316,11 @@ def jobby(args):
         warnings.warn("⚠️ No job IDs to process.")
 
     records = get_sacct_info(job_ids)
-    if not records:
+    if records:
+        df = records_to_df(records)
+        print(format_df(df, output_format))
+    else:
         warnings.warn("⚠️ No job data found.")
-
-    df = records_to_df(records)
-    print(format_df(df, output_format))
 
 
 def main():

--- a/tests/test_jobby.py
+++ b/tests/test_jobby.py
@@ -112,9 +112,9 @@ def test_jobby_no_records():
 
 @pytest.mark.skipif(HPC != "biowulf", reason="only works on biowulf")
 def test_jobby_no_records_biowulf():
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.warns(UserWarning) as exc_info:
         jobby(["invalid_job_id"])
-    assert "Failed to fetch info for JobID" in str(exc_info.value)
+    assert "Failed to fetch info for JobID" in str(exc_info[0].message)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Changes

- pipeline_path as optional spooker argument: this way we don't have to run `which pipeline` to infer the path inaccurately. optional so it's backwards compatible.
- fix problems in new jobby behavior for real pipeline use

## Issues

resolves #57

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
