### PR TITLE
feat: add version and help options to jobby command

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ guidelines](https://CCBR.github.io/Tools/CONTRIBUTING).
 Please cite this software if you use it in a publication:
 
 > Sovacool K., Koparde V., Kuhn S., Tandon M., and Huse S. (2025). CCBR
-> Tools: Utilities for CCBR Bioinformatics Software (version v0.3.2).
+> Tools: Utilities for CCBR Bioinformatics Software (version v0.4.0).
 > DOI: 10.5281/zenodo.13377166 URL: https://ccbr.github.io/Tools/
 
 ### Bibtex entry

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -335,7 +335,7 @@ def main():
         print("  jobby .nextflow.log [--tsv|--json|--yaml]")
         print("  jobby -v or --version")
         print("  jobby -h or --help")
-    elif len(args) == 1 and ('-v' in args or '--version' in args):
+    elif len(args) == 1 and ("-v" in args or "--version" in args):
         # read in the file "VERSION" in the current directory
         version_file = os.path.join(os.path.dirname(__file__), "VERSION")
         if os.path.isfile(version_file):

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -333,6 +333,18 @@ def main():
         print("  jobby <jobid1>,<jobid2> [--tsv|--json|--yaml]")
         print("  jobby snakemake.log [--tsv|--json|--yaml]")
         print("  jobby .nextflow.log [--tsv|--json|--yaml]")
+        print("  jobby -v or --version")
+        print("  jobby -h or --help")
+    elif len(args) == 1 and ('-v' in args or '--version' in args):
+        # read in the file "VERSION" in the current directory
+        version_file = os.path.join(os.path.dirname(__file__), "VERSION")
+        if os.path.isfile(version_file):
+            with open(version_file, "r") as f:
+                version = f.read().strip()
+                # add prefix "v" to the version string if not already present
+                if not version.startswith("v"):
+                    version = "v" + version
+            print(f"jobby: ccbr_tools version: {version}")
     else:
         jobby(args)
 

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -37,6 +37,7 @@ EXAMPLES:
     jobby 12345678,12345679 --tsv
 
 """
+from .pkg_util import get_version
 
 import subprocess
 import sys

--- a/tests/test_jobby.py
+++ b/tests/test_jobby.py
@@ -18,6 +18,7 @@ from ccbr_tools.jobby import (
     format_df,
 )
 from ccbr_tools.pipeline.hpc import get_hpcname
+from ccbr_tools.shell import shell_run
 
 HPC = get_hpcname()
 
@@ -271,3 +272,8 @@ def test_format_df():
         )  # extra newline when files were printed
         assertions.append([actual, expected])
     assert all([actual == expected for actual, expected in assertions])
+
+
+def test_jobby_version():
+    output = shell_run("jobby --version")
+    assert output.startswith("jobby: ccbr_tools version: ")

--- a/tests/test_jobby.py
+++ b/tests/test_jobby.py
@@ -276,4 +276,10 @@ def test_format_df():
 
 def test_jobby_version():
     output = shell_run("jobby --version")
-    assert output.startswith("jobby: ccbr_tools version: ")
+    this_version = shell_run("ccbr_tools --version").split()[-1]
+    assert all(
+        [
+            output.startswith("jobby: ccbr_tools version: "),
+            output.strip().endswith(this_version),
+        ]
+    )


### PR DESCRIPTION
- adding version details
- sacct cannot get `.out` or `.err` ... needs to deal with this in `spooker`