### PR TITLE
feat(spooker): use CLI options rather than positional args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Tools development version
 
+- **Breaking change**: Spooker now takes named options rather than positional arguments. (#85, @kelly-sovacool)
 - Minor documentation improvements. (#81, @kelly-sovacool)
 
 ## Tools 0.4.0

--- a/src/ccbr_tools/spooker.py
+++ b/src/ccbr_tools/spooker.py
@@ -24,23 +24,23 @@ from .shell import get_groups, shell_run
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.argument("outdir", type=click.Path(exists=True), default=pathlib.Path.cwd())
-@click.argument("name", type=str, default="")
-@click.argument("version", type=str, default="")
-@click.argument("path", type=click.Path(), default="")
+@click.option(
+    "--outdir",
+    type=click.Path(exists=True),
+    default=pathlib.Path.cwd(),
+    help="Output directory for the pipeline run",
+)
+@click.option("--name", type=str, default="", help="Name of the pipeline")
+@click.option("--version", type=str, default="", help="Version of the pipeline")
+@click.option(
+    "--path", type=click.Path(), default="", help="Path to the pipeline source"
+)
 def cli(outdir, name, version, path):
     """
     spooker 👻
 
     This command is designed to be used as part of the OnComplete/OnSuccess/OnError handlers as part of Snakemake and Nextflow pipelines.
     It collects metadata about the pipeline run, bundles it into a tarball, and saves it to a common location for later retrieval.
-
-    \b
-    Args:
-        outdir: Output directory for the pipeline run
-        name: Name of the pipeline
-        version: Version of the pipeline
-        path: Path to the pipeline source
     """
     spooker(
         outdir,

--- a/src/ccbr_tools/spooker.py
+++ b/src/ccbr_tools/spooker.py
@@ -35,7 +35,13 @@ from .shell import get_groups, shell_run
 @click.option(
     "--path", type=click.Path(), default="", help="Path to the pipeline source"
 )
-def cli(outdir, name, version, path):
+@click.option(
+    "--debug",
+    default=None,
+    help="Enable debug mode for the HPC cluster",
+    hidden=True,
+)
+def cli(outdir, name, version, path, debug):
     """
     spooker 👻
 
@@ -47,6 +53,7 @@ def cli(outdir, name, version, path):
         name,
         version,
         path,
+        debug=debug,
     )
 
 

--- a/tests/test_spooker.py
+++ b/tests/test_spooker.py
@@ -52,6 +52,41 @@ def test_spooker_no_outdir():
 
 
 def test_spooker_cli():
+    out = subprocess.run(
+        "spooker --outdir tests/data/pipeline_run --name test_pipeline --version 0.1.2-dev --path unknown --debug gha",
+        shell=True,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    print("OUT", out)
+    out_filename = out.split()[-1]
+    with gzip.open(out_filename, "rt") as file:
+        spook_dat = json.load(file)
+
+    expected_meta = {
+        "ccbrpipeliner_module": None,
+        "pipeline_name": "test_pipeline",
+        "pipeline_outdir": "tests/data/pipeline_run",
+        "pipeline_path": "unknown",
+        "pipeline_version": "0.1.2-dev",
+        "sample_names": [],
+    }
+    actual_meta = {
+        k: v
+        for k, v in spook_dat["pipeline_metadata"].items()
+        if k in expected_meta.keys()
+    }
+    assert all(
+        [
+            expected_meta == actual_meta,
+            spook_dat.keys()
+            == {"outdir_tree", "pipeline_metadata", "jobby", "master_job_log"},
+        ]
+    )
+
+
+def test_spooker_help():
     assert (
         "Usage: spooker "
         in subprocess.run(


### PR DESCRIPTION
## Changes

This is a breaking change. The spooker CLI now takes named options rather than positional arguments.

## Issues

fixes #84

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
