### PR TITLE
fix: spacesavers2 is technically not a python package

### DIFF
--- a/src/ccbr_tools/software.py
+++ b/src/ccbr_tools/software.py
@@ -137,7 +137,7 @@ CCBR_SOFTWARE = {
     "renee": Snakemake,
     "sinclair": Nextflow,
     "xavier": Snakemake,
-    "spacesavers2": PythonTool,
+    "spacesavers2": BashTool,
     "permfix": BashTool,
     "ccbr_tools": PythonTool,
     "ccbr_actions": PythonTool,


### PR DESCRIPTION
## Changes

There's no pyproject.toml or setup.py. It is organized like our snakemake pipelines with the `bin/redirect` bash script.


## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [ ] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] Write unit tests for any new features, bug fixes, or other code changes.
- [ ] Update docs if there are any API changes.
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
