### PR TITLE
fix: handle tabs & newline chars in slurm out/err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Tools development version
 
-- Use miniforge3 installation on biowulf. (#124, @kelly-sovacool)
+- Fix how jobby parses slurm stdout/stderr files. (#122, @kopardev, @kelly-sovacool)
 - The `run_jobby_on_*` scripts are now deprecated in favor of using `jobby` directly. (#123, @kelly-sovacool)
+- Use miniforge3 installation on biowulf. (#124, @kelly-sovacool)
 
 ## Tools 0.4.4
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ guidelines](https://CCBR.github.io/Tools/CONTRIBUTING).
 Please cite this software if you use it in a publication:
 
 > Sovacool K., Koparde V., Kuhn S., Tandon M., and Huse S. (2025). CCBR
-> Tools: Utilities for CCBR Bioinformatics Software (version v0.4.3).
+> Tools: Utilities for CCBR Bioinformatics Software (version v0.4.4).
 > DOI: 10.5281/zenodo.13377166 URL: https://ccbr.github.io/Tools/
 
 ### Bibtex entry
@@ -172,7 +172,7 @@ Please cite this software if you use it in a publication:
 @misc{YourReferenceHere,
 author = {Sovacool, Kelly and Koparde, Vishal and Kuhn, Skyler and Tandon, Mayank and Huse, Susan},
 doi = {10.5281/zenodo.13377166},
-month = {6},
+month = {9},
 title = {CCBR Tools: Utilities for CCBR Bioinformatics Software},
 url = {https://ccbr.github.io/Tools/},
 year = {2025}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,7 +88,7 @@ def test_install():
     output = shell_run("ccbr_tools install champagne v0.3.0 --hpc biowulf", check=False)
     assert all(
         [
-            "conda.sh' && conda activate /" in output,
+            "mamba activate /" in output,
             output.endswith(
                 """pip install git+https://github.com/CCBR/CHAMPAGNE.git@v0.3.0 -t /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0
 chmod -R a+rX /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0

--- a/tests/test_jobby.py
+++ b/tests/test_jobby.py
@@ -313,10 +313,8 @@ def test_format_df():
 
 def test_get_job_logs():
     assert get_job_logs("abc", "tests/data/pipeline/work") == {
-        "log_err_path": "tests/data/pipeline/work/.command.err",
-        "log_err_txt": "WARNING: Not virtualizing pid namespace by configuration\n"
-        "WARNING: While bind mounting '/gpfs:/gpfs': destination is "
-        "already in the mount point list\n",
         "log_out_path": "tests/data/pipeline/work/.command.out",
         "log_out_txt": "",
+        "log_err_path": "tests/data/pipeline/work/.command.err",
+        "log_err_txt": "WARNING: Not virtualizing pid namespace by configuration\\nWARNING: While bind mounting '/gpfs:/gpfs': destination is already in the mount point list\\n",
     }

--- a/tests/test_pipeline_hpc.py
+++ b/tests/test_pipeline_hpc.py
@@ -15,7 +15,7 @@ def test_hpc_biowulf():
             hpc.__repr__().startswith(
                 "<class 'ccbr_tools.pipeline.hpc.Biowulf'>({'name': 'biowulf'"
             ),
-            "conda.sh' && conda activate /" in hpc.CONDA_ACTIVATE,
+            "mamba activate /" in hpc.CONDA_ACTIVATE,
         ]
     )
 
@@ -28,7 +28,7 @@ def test_hpc_frce():
             hpc.name == "frce",
             "/mnt/projects/CCBR-Pipelines/bin" in hpc.env_vars,
             hpc.singularity_sif_dir == "/mnt/projects/CCBR-Pipelines/SIFs",
-            "conda.sh' && conda activate " in hpc.CONDA_ACTIVATE,
+            "mamba activate " in hpc.CONDA_ACTIVATE,
         ]
     )
 


### PR DESCRIPTION
## Changes

Properly handle tab & newline chars in slurm stdout/stderr files

## Issues

fixes #118 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
