### PR TITLE
fix: deprecate run_jobby_* scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Tools development version
 
 - Use miniforge3 installation on biowulf. (#124, @kelly-sovacool)
+- The `run_jobby_on_*` scripts are now deprecated in favor of using `jobby` directly. (#123, @kelly-sovacool)
 
 ## Tools 0.4.4
 

--- a/docs/scripts.qmd
+++ b/docs/scripts.qmd
@@ -5,6 +5,10 @@ title: "External scripts"
 Additional standalone scripts for various common tasks are added to the path when this package is installed.
 They are less robust than the [CLI Utilities](cli) included in the package and do not have any unit tests.
 
+:::{.callout-warning}
+The `run_jobby_on_*` scripts have been deprecated. Please use `jobby` directly.
+:::
+
 ```{python}
 #| echo: false
 #| output: asis

--- a/scripts/run_jobby_on_nextflow_log
+++ b/scripts/run_jobby_on_nextflow_log
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
-nextflowlog=$1
-jobby $(awk -F" jobId: " '{print $2}' ${nextflowlog} | awk -F";" '{print $1}' | grep -v "^$" | sort | uniq | tr "\\n" " ") |cut -f2,3,18
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+echo """ERROR: ${SCRIPT} is deprecated.
+Please use jobby instead. For usage information, run:
+
+    jobby --help
+""" >&2
+exit 1

--- a/scripts/run_jobby_on_nextflow_log_full_format
+++ b/scripts/run_jobby_on_nextflow_log_full_format
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
-nextflowlog=$1
-jobby $(awk -F" jobId: " '{print $2}' ${nextflowlog} | awk -F";" '{print $1}' | grep -v "^$" | sort | uniq | tr "\\n" " ")
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+echo """ERROR: ${SCRIPT} is deprecated.
+Please use jobby instead. For usage information, run:
+
+    jobby --help
+""" >&2
+exit 1

--- a/scripts/run_jobby_on_snakemake_log
+++ b/scripts/run_jobby_on_snakemake_log
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
-snakemakelog=$1
-jobby $(grep --color=never "^Submitted .* with external jobid" $snakemakelog | awk '{{print $NF}}'  | sed "s/['.]//g" | sort | uniq | tr "\\n" " ") |cut -f2,3,18
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+echo """ERROR: ${SCRIPT} is deprecated.
+Please use jobby instead. For usage information, run:
+
+    jobby --help
+""" >&2
+exit 1

--- a/scripts/run_jobby_on_snakemake_log_full_format
+++ b/scripts/run_jobby_on_snakemake_log_full_format
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
-snakemakelog=$1
-jobby $(grep --color=never "^Submitted .* with external jobid" $snakemakelog | awk '{{print $NF}}'  | sed "s/['.]//g" | sort | uniq | tr "\\n" " ")
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+echo """ERROR: ${SCRIPT} is deprecated.
+Please use jobby instead. For usage information, run:
+
+    jobby --help
+""" >&2
+exit 1


### PR DESCRIPTION
## Changes

Print an error message and direct users to run `jobby` directly instead

These scripts no longer worked with jobby as of ccbr_tools v0.4.0 anyway

## Issues

fixes #119

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
