### PR TITLE
fix: lazy-import cffconvert to fix rpds ABI mismatch on Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Tools development version
 
+- `pkg_util`: Lazy-import cffconvert to fix rpds ABI mismatch on Python 3.12. (#182, @kopardev)
 - `ccbr-hooks detect-absolute-paths`: Reduce false positives caused by `/dev/null`. (#174, @kelly-sovacool)
 
 ## Tools 0.5.2

--- a/src/ccbr_tools/pkg_util.py
+++ b/src/ccbr_tools/pkg_util.py
@@ -2,8 +2,6 @@
 Miscellaneous utility functions for the package
 """
 
-from cffconvert.cli.create_citation import create_citation
-from cffconvert.cli.validate_or_write_output import validate_or_write_output
 import click
 import datetime
 import importlib.resources
@@ -125,6 +123,9 @@ def print_citation(citation_file=repo_base("CITATION.cff"), output_format="bibte
         citation_file (str): The path to the citation file.
         output_format (str): The desired output format for the citation.
     """
+    from cffconvert.cli.create_citation import create_citation
+    from cffconvert.cli.validate_or_write_output import validate_or_write_output
+
     citation = create_citation(citation_file, None)
     # click.echo(citation._implementation.cffobj['message'])
     validate_or_write_output(None, output_format, False, citation)


### PR DESCRIPTION
## Summary
- Fixes issue #182: lazy-import cffconvert in pkg_util.py
- Moves cffconvert imports from module level to inside the `print_citation()` function
- This defers the problematic import chain to rpds (which only has Python 3.11 binaries) until the citation feature is explicitly requested
- Allows the package to be imported successfully on Python 3.12

## Changes
- `src/ccbr_tools/pkg_util.py`: Move cffconvert imports to lazy-load pattern
- `CHANGELOG.md`: Add entry for issue #182

## Test plan
- [x] Existing tests should pass (import tests, CLI tests)
- [x] Module can be imported on Python 3.12 without cffconvert installed
- [x] Citation feature works when invoked with `cite` command

## References
Follows the same pattern successfully applied to RENEE in commit 82c32d1