### PR TITLE
refactor: apply python coding instructions repo-wide

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,14 @@
+---
+name: "Python Standards"
+description: "Coding conventions for Python files"
+applyTo: "**/*.py"
+---
+
+# Python coding standards
+
+- Follow the PEP 8 style guide.
+- Use 4 spaces for indentation.
+- Write docstrings for public functions in Google style, using quartodoc interlinks when applicable.
+- If a function has any `return` statement, there should be only one `return` statement as the last line of the function.
+- Do not use `continue` or `break` in loops.
+- Do not use bare `except` clauses; always specify the expected exception type.

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -32,11 +32,10 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
-          ref: ${{ github.head_ref && github.event_name == 'pull_request' || github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
       - name: git config
         run: |
@@ -61,6 +60,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
         continue-on-error: true
       - name: commit & push
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/filter_fastq_by_readids_highmem.py
+++ b/scripts/filter_fastq_by_readids_highmem.py
@@ -5,6 +5,7 @@ import os
 
 
 def get_sname(s):
+    """Return the sample name from the input path."""
     sname = s.name
     sname = sname.split()[0]
     return sname

--- a/scripts/filter_fastq_by_readids_highmem_pe.py
+++ b/scripts/filter_fastq_by_readids_highmem_pe.py
@@ -5,12 +5,14 @@ import os
 
 
 def get_sname(s):
+    """Return the sample name from the input path."""
     sname = s.name
     sname = sname.split()[0]
     return sname
 
 
 def fixoutfilename(f):
+    """Return the normalized output filename."""
     outfqfilename = f
     dummy = outfqfilename.strip().split(".")
     if dummy[-1] == "gz":

--- a/src/ccbr_tools/GSEA/deg2gs.py
+++ b/src/ccbr_tools/GSEA/deg2gs.py
@@ -38,6 +38,7 @@ from .ncbr_huse import send_update, err_out
 ####################################
 def filter_by_p(x, nhits, pvalue, qvalue):
     # Filter the data to nhits, pvalue, qvalue
+    """Filter rows by p-value."""
     x.sort_values(by=["p"], inplace=True)
     x = x[(x["p"] <= pvalue) & (x["q"] <= qvalue)]
     if x.shape[0] > nhits:
@@ -54,6 +55,7 @@ def filter_by_p(x, nhits, pvalue, qvalue):
 
 def main():
     # Usage statement
+    """Run the CLI."""
     parseStr = "Reads RNASeq differential expression output files\n\
 and outputs a prioritized list of genes for use in GSEA or ToppFun.\n\
 Will filter by both p and fdr values, and export up to nhits values.\n\

--- a/src/ccbr_tools/GSEA/multitext2excel.py
+++ b/src/ccbr_tools/GSEA/multitext2excel.py
@@ -55,6 +55,7 @@ from .ncbr_huse import (
 
 def main():
     # Usage statement
+    """Run the CLI."""
     parseStr = (
         'Reads a list of files and imports them each into a separate tab in one Excel spreadsheet.\n\n\
     Usage:\n\

--- a/src/ccbr_tools/GSEA/ncbr_huse.py
+++ b/src/ccbr_tools/GSEA/ncbr_huse.py
@@ -33,6 +33,7 @@ except ImportError:  # Optional dependency, only needed for con_db
 def run_cmd(theCommand, fn, dorun):
     # Run the given command, x is a list of command parameters
     # if dorun = false, just send out the notification of the next python step
+    """Run a shell command and capture its output."""
     print(" ".join(theCommand) + "\n")
     fn.write(" ".join(theCommand) + "\n")
     fn.flush()
@@ -46,6 +47,7 @@ def run_cmd(theCommand, fn, dorun):
 def run_os_cmd(theCommand, fn, dorun):
     # Run the given command, x is a list of command parameters
     # if dorun = false, just send out the notification of the next python step
+    """Run an operating-system command."""
     theCommandStr = " ".join(theCommand)
     print(theCommandStr + "\n")
     fn.write(theCommandStr + "\n")
@@ -60,6 +62,7 @@ def run_os_cmd(theCommand, fn, dorun):
 def un_gzip(fname, logfn):
     # If rerunning and the previous step has already been compressed,
     # need to uncompress it before you can rerun the command
+    """Decompress a gzipped file."""
     gzip_name = fname + ".gz"
     if (not os.path.isfile(fname)) and os.path.isfile(gzip_name):
         ungz_cmd = ["gunzip", gzip_name]
@@ -70,6 +73,7 @@ def un_gzip(fname, logfn):
 # Read ~/.my.cnf and connect to an SQL database
 #
 def con_db(host_name, db_name, port_number):
+    """Connect to the database."""
     if MySQLdb is None:
         raise ModuleNotFoundError(
             "MySQLdb is required for database connections. Install mysqlclient."
@@ -96,6 +100,7 @@ def con_db(host_name, db_name, port_number):
 # Print updates to screen and log file
 #
 def send_update(updateStr, log=None, quiet=False):
+    """Send a status update."""
     if not quiet:
         print(updateStr)
 
@@ -108,6 +113,7 @@ def send_update(updateStr, log=None, quiet=False):
 # Log error message and exit
 #
 def err_out(errMsg, log=None):
+    """Exit with an error message."""
     if log is not None:
         log.write(errMsg)
 
@@ -118,11 +124,13 @@ def err_out(errMsg, log=None):
 # Pause for user to be ready to continue, use contkey=None to get any input
 #
 def pause_for_input(txt, contkey="y", quitkey="q", log=None):
+    """Pause until the user provides a valid response."""
     # tally the number of tries
     answer_cnt = 0
+    result = None
 
     # loop for the user to enter input, give them a few tries
-    while True:
+    while result is None:
         # wait for the input
         answer = input(txt)
 
@@ -132,11 +140,11 @@ def pause_for_input(txt, contkey="y", quitkey="q", log=None):
 
         # if none, just return the input
         if contkey is None:
-            return answer
+            result = answer
 
         # if there is a contkey, then be sure it is correctly typed
         elif answer == contkey:
-            return answer
+            result = answer
 
         else:
             # give them additional help and increment the answer count
@@ -156,12 +164,14 @@ def pause_for_input(txt, contkey="y", quitkey="q", log=None):
                 )
 
             answer_cnt = answer_cnt + 1
+    return result
 
 
 #
 # Count sequences in a fasta file
 #
 def fasta_count(fastaFile):
+    """Count FASTA records in a file."""
     seqcount = 0
     for line in open(fastaFile, "r"):
         if re.match(">", line):
@@ -173,6 +183,7 @@ def fasta_count(fastaFile):
 # Count sequences in a fasta file
 #
 def fasta_list(fastaFile):
+    """List FASTA record identifiers."""
     seqs = []
     for line in open(fastaFile, "r"):
         if re.match(">", line):

--- a/src/ccbr_tools/__main__.py
+++ b/src/ccbr_tools/__main__.py
@@ -212,6 +212,7 @@ cli.add_command(version)
 
 
 def main():
+    """Run the CLI."""
     cli(prog_name="ccbr_tools")
 
 

--- a/src/ccbr_tools/gb2gtf.py
+++ b/src/ccbr_tools/gb2gtf.py
@@ -14,6 +14,7 @@ import Bio
 
 
 def main():
+    """Run the CLI."""
     if check_args(sys.argv):
         gb2gtf(sys.argv)
 
@@ -25,6 +26,7 @@ Usage: gb2gtf sequence.gb > sequence.gtf
 
 
 def check_args(args):
+    """Validate the CLI arguments."""
     valid_usage = True
     if len(args) < 2 or "-h" in args or "--help" in args:
         print(usage_msg)
@@ -34,6 +36,7 @@ def check_args(args):
 
 def gb2gtf(args):
     # get all sequence records for the specified genbank file
+    """Convert a GenBank file to GTF output."""
     recs = [rec for rec in SeqIO.parse(args[1], "genbank")]
 
     # print the number of sequence records that were extracted
@@ -126,10 +129,6 @@ def gb2gtf(args):
                     y = x + "; exon_number 1"
                     gffstring[8] = y
                     print("\t".join(gffstring) + ";")
-
-            #            print(j,part)
-            else:
-                continue
 
             # else:
 

--- a/src/ccbr_tools/github.py
+++ b/src/ccbr_tools/github.py
@@ -60,11 +60,12 @@ def get_user_info(user_login):
               If the user is not found, returns a minimal dict with 'login' and 'name' set to None.
     """
     url = f"https://api.github.com/users/{user_login}"
+    user_info = {"login": user_login, "name": None}
     try:
-        return get_url_json(url)
+        user_info = get_url_json(url)
     except ConnectionError as e:
         warnings.warn(f"Could not retrieve user info for {user_login}. {str(e)}")
-        return {"login": user_login, "name": None}
+    return user_info
 
 
 def get_contrib_html(contrib, img_attr="{width=100px height=100px}"):

--- a/src/ccbr_tools/homologfinder/hf.py
+++ b/src/ccbr_tools/homologfinder/hf.py
@@ -94,6 +94,7 @@ def collect_args():
 
 
 def process_genelist(gl, lookup):
+    """Expand a gene list with homologs from the lookup table."""
     result = []
     for g in gl:
         if g in lookup:
@@ -102,6 +103,7 @@ def process_genelist(gl, lookup):
 
 
 def process_args(args, lookup):
+    """Process CLI arguments into a gene list."""
     if args.gene:
         r = process_genelist([args.gene], lookup)
     if args.genelist:
@@ -116,11 +118,13 @@ def process_args(args, lookup):
 
 
 def print_results(result):
+    """Print the homolog finder results."""
     for g in result:
         print(g)
 
 
 def read_lookup():
+    """Read the homolog lookup table."""
     lookup = dict()
     lookup_filepath = (
         importlib.resources.files(__package__) / "human_mouse_homolog_lookup.txt"
@@ -135,6 +139,7 @@ def read_lookup():
 def create_homolog_table(
     rpt_file=importlib.resources.files(__package__) / "HOM_MouseHumanSequence.rpt",
 ):
+    """Create the homolog lookup table."""
     cols = ["DB Class Key", "Common Organism Name", "Symbol"]
     df = pd.read_csv(rpt_file, usecols=cols, sep="\t")
     # human-mouse homologs file --> HOM_MouseHumanSequence.rpt
@@ -146,9 +151,10 @@ def create_homolog_table(
             lookup[row["DB Class Key"]] = dict()
             lookup[row["DB Class Key"]]["mouse, laboratory"] = list()
             lookup[row["DB Class Key"]]["human"] = list()
-        if row["Common Organism Name"] not in lookup[row["DB Class Key"]]:
-            continue
-        lookup[row["DB Class Key"]][row["Common Organism Name"]].append(row["Symbol"])
+        if row["Common Organism Name"] in lookup[row["DB Class Key"]]:
+            lookup[row["DB Class Key"]][row["Common Organism Name"]].append(
+                row["Symbol"]
+            )
     for k, v in lookup.items():
         # print(",".join(v["mouse, laboratory"]),",".join(v["human"]),sep="\t")
         for gene_symbol in v["mouse, laboratory"]:
@@ -165,10 +171,12 @@ def create_homolog_table(
 
 
 def hf(args):
+    """Run the homolog finder lookup."""
     return process_args(args, read_lookup())
 
 
 def main():
+    """Run the CLI."""
     args = collect_args()
     results = hf(args)
     print_results(results)

--- a/src/ccbr_tools/hooks/__main__.py
+++ b/src/ccbr_tools/hooks/__main__.py
@@ -33,6 +33,7 @@ cli.add_command(sync_nextflow_version)
 
 
 def main():
+    """Run the CLI."""
     cli(prog_name="ccbr-hooks")
 
 

--- a/src/ccbr_tools/hooks/detect_absolute_paths.py
+++ b/src/ccbr_tools/hooks/detect_absolute_paths.py
@@ -124,9 +124,11 @@ def raise_error_if_abs_paths_detected(files, ignored_patterns=None):
             for idx in range(1, len(parts)):
                 match_targets.append(pathlib.Path(*parts[idx:]))
 
-            if any(spec.match_file(target.as_posix()) for target in match_targets):
-                continue
-            filtered_files.append(file)
+            is_ignored = any(
+                spec.match_file(target.as_posix()) for target in match_targets
+            )
+            if not is_ignored:
+                filtered_files.append(file)
         files = filtered_files
 
     if any([file_contains_absolute_path(file) for file in files]):
@@ -138,16 +140,13 @@ def load_ignored_paths(ignored_paths_file):
     Load ignored file paths/patterns from a file, one per line.
     Supports gitignore-style wildcards.
     """
-    if not ignored_paths_file:
-        return []
-
     patterns = []
-    with open(ignored_paths_file, "r") as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            patterns.append(stripped)
+    if ignored_paths_file:
+        with open(ignored_paths_file, "r") as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#"):
+                    patterns.append(stripped)
 
     return patterns
 

--- a/src/ccbr_tools/intersect.py
+++ b/src/ccbr_tools/intersect.py
@@ -12,6 +12,7 @@ import sys
 
 
 def indexFile(filename, joinindex, header):
+    """Index a tab-delimited file by the join column."""
     fh = open(filename, "r")
     filedict = {}
     if header == 1:
@@ -28,6 +29,7 @@ def indexFile(filename, joinindex, header):
 
 
 def intersect(fileDict, file2, joinindex, header):
+    """Print the intersecting rows between two files."""
     fh2 = open(file2, "r")
     counter = 0
 
@@ -42,22 +44,19 @@ def intersect(fileDict, file2, joinindex, header):
         linelist = line.strip().replace('"', "").split("\t")
         # print(linelist)
         joinon = linelist[joinindex]
-        try:
-            fileDict[joinon]
-        except KeyError:
-            continue  # joinon key is not in the file1, go to next line in file
-
-        counter += 1
-        intersection = (
-            "\t".join(fileDict[joinon]).rstrip("\n") + "\t" + "\t".join(linelist)
-        )
-        print(intersection)
+        if joinon in fileDict:
+            counter += 1
+            intersection = (
+                "\t".join(fileDict[joinon]).rstrip("\n") + "\t" + "\t".join(linelist)
+            )
+            print(intersection)
 
     # print(counter)
     fh2.close()
 
 
 def run_intersect(args):
+    """Run the intersect command."""
     usage_str = "USAGE:\nintersect filename1 filename2 f1ColumnIndex F2ColumnIndex\n\t--Ex. intersect file1 file2 0 0"
     # Join on column count starts at 0
     if "--help" in args or "-h" in args:
@@ -82,6 +81,7 @@ def run_intersect(args):
 
 
 def main():
+    """Run the CLI."""
     run_intersect(sys.argv)
 
 

--- a/src/ccbr_tools/jobby.py
+++ b/src/ccbr_tools/jobby.py
@@ -162,14 +162,13 @@ def extract_jobids_from_file(filepath):
                 match_snakemake = re.search(r"external jobid\s+['\"](\d+)['\"]", line)
                 if match_snakemake:
                     job_ids.append(match_snakemake.group(1))
-                    continue  # no need to check further if matched
-
-                # Match Nextflow pattern: (JOB ID: 12345)
-                match_nextflow = re.search(
-                    r"\[Task submitter\].*?>\s*jobId:\s*(\d+);", line
-                )
-                if match_nextflow:
-                    job_ids.append(match_nextflow.group(1))
+                else:
+                    # Match Nextflow pattern: (JOB ID: 12345)
+                    match_nextflow = re.search(
+                        r"\[Task submitter\].*?>\s*jobId:\s*(\d+);", line
+                    )
+                    if match_nextflow:
+                        job_ids.append(match_nextflow.group(1))
     except FileNotFoundError:
         warnings.warn(f"❌ File not found: {filepath}")
     return list(sorted(set(job_ids)))  # deduplicate
@@ -182,6 +181,7 @@ def list_records(
     completed_state="COMPLETED",
     success_exit_code=0,
 ):
+    """List job records for the given job IDs."""
     return list(
         itertools.chain.from_iterable(
             [
@@ -205,6 +205,7 @@ def get_sacct_info(
     completed_state="COMPLETED",
     success_exit_code=0,
 ):
+    """Get sacct records for a job ID."""
     job_records = {}
     try:
         sacct_cmd = [
@@ -293,6 +294,7 @@ def read_slurm_log(filepath):
 
 
 def get_job_logs(job_id, workdir, include_text=True):
+    """Get job log paths and contents."""
     job_logs = {}
     if workdir:
         out_files = glob_files(workdir, patterns=[f"*{job_id}*.out", ".command.out"])
@@ -441,6 +443,7 @@ def jobby(
 
 
 def main():
+    """Run the CLI."""
     args = sys.argv[1:]
     if len(args) == 0 or "-h" in args or "--help" in args:
         print("Usage:")

--- a/src/ccbr_tools/jobinfo.py
+++ b/src/ccbr_tools/jobinfo.py
@@ -60,6 +60,7 @@ def check_help(parser):
 
 
 def check_host():
+    """Validate that the current host is supported."""
     if (
         os.environ.get("HOSTNAME") == "biowulf.nih.gov"
         or os.environ.get("HOSTNAME") == "helix.nih.gov"
@@ -71,6 +72,7 @@ def check_host():
 
 def collect_args():
     # create parser
+    """Parse the CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Get slurm job information using slurm job id or snakemake.log file"
     )
@@ -149,18 +151,23 @@ def collect_args():
 
 
 def mem2gb(memstr):
+    """Convert a memory string to gigabytes."""
+    result = None
     if memstr == "0":
-        return float("0")
-    value, unit = memstr.split()
-    if unit == "GB":
-        return float(value)
-    elif unit == "MB":
-        return float(value) / 1024
-    elif unit == "KB":
-        return float(value) / 1024 / 1024
+        result = float("0")
+    else:
+        value, unit = memstr.split()
+        if unit == "GB":
+            result = float(value)
+        elif unit == "MB":
+            result = float(value) / 1024
+        elif unit == "KB":
+            result = float(value) / 1024 / 1024
+    return result
 
 
 def check_int_set_zero(s):
+    """Convert an empty string to zero or cast it to an integer."""
     if s == "":
         s = 0
     else:
@@ -169,6 +176,7 @@ def check_int_set_zero(s):
 
 
 def time2sec(timestr):
+    """Convert a SLURM time string to seconds."""
     debug = 0
     dayHMSstr_list = timestr.split("-")
     if debug == 1:
@@ -215,6 +223,7 @@ def time2sec(timestr):
 
 
 def get_jobinfo(args):
+    """Retrieve job information from dashboard_cli."""
     cmd = (
         "/usr/local/bin/dashboard_cli jobs --joblist "  # abs-path:ignore
         + ",".join(args.joblist)
@@ -289,7 +298,10 @@ def get_jobinfo(args):
 
 
 def filter_rows(func):
+    """Filter rows."""
+
     def wrapper(t, args):
+        """Filter rows before invoking the wrapped function."""
         if args.failonly:
             t = t[t["state"].isin(FAILONLY.split(","))]
         func(t, args)
@@ -299,6 +311,7 @@ def filter_rows(func):
 
 @filter_rows
 def print2screen(t, args):
+    """Print the job table to the screen."""
     onscreenfields = SHORT_FIELDS
     if args.failonly:
         onscreenfields = FAILONLY_FIELDS
@@ -312,6 +325,7 @@ def print2screen(t, args):
 
 def main():
     # collect all arguments
+    """Run the CLI."""
     args = collect_args()
     # check host
     check_host()

--- a/src/ccbr_tools/module_list.py
+++ b/src/ccbr_tools/module_list.py
@@ -56,6 +56,7 @@ from .pipeline.hpc import list_modules, parse_modules
 
 
 def print_help():
+    """Print the CLI help text."""
     help_message = """
 Usage:
   module_list           # List all loaded modules in JSON format
@@ -87,6 +88,7 @@ def module_list(module=""):
 
 
 def main():
+    """Run the CLI."""
     args = sys.argv
     if "-h" in args or "--help" in args or len(args) > 2:
         print_help()

--- a/src/ccbr_tools/paths.py
+++ b/src/ccbr_tools/paths.py
@@ -53,6 +53,7 @@ def load_tree(tree_str):
 
 
 def get_disk_usage(tree_dict, pipeline_outdir):
+    """Get disk usage."""
     try:
         report = next(
             (

--- a/src/ccbr_tools/peek.py
+++ b/src/ccbr_tools/peek.py
@@ -82,6 +82,7 @@ def peek(filename, buffer, delim="\t"):
     # pargs()
 
     # Getting contents of first line
+    """Peek at the input data."""
     try:
         fh = open(filename, "r")
     except IOError as e:
@@ -110,6 +111,7 @@ def peek(filename, buffer, delim="\t"):
 
 def main():
     # Checking command-line usage before parsing
+    """Run the CLI."""
     pargs()
 
     try:

--- a/src/ccbr_tools/pipeline/hpc.py
+++ b/src/ccbr_tools/pipeline/hpc.py
@@ -45,6 +45,7 @@ class Cluster:
     __nonzero__ = __bool__
 
     def spook(self, file, subdir=None):
+        """Inspect the HPC execution environment."""
         dest_dir = self.SPOOK_DIR / subdir if subdir else self.SPOOK_DIR
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy(file, dest_dir)
@@ -52,10 +53,12 @@ class Cluster:
 
     @property
     def singularity_sif_dir(self):
+        """Singularity sif dir."""
         return get_sif_cache_dir(hpc=self.name)
 
     @staticmethod
     def create_hpc(debug=False):
+        """Create hpc."""
         hpc_options = {
             "biowulf": Biowulf,
             "frce": FRCE,
@@ -255,6 +258,7 @@ def is_loaded(module="ccbrpipeliner"):
 
 
 def main():
+    """Run the CLI."""
     HPC = get_hpcname()
     print(f"{HPC}")
 

--- a/src/ccbr_tools/pipeline/util.py
+++ b/src/ccbr_tools/pipeline/util.py
@@ -117,11 +117,11 @@ def md5sum(filename, first_block_only=False, blocksize=65536):
             # calculating an MD5 checksum of thousand or
             # millions of file.
             hasher.update(buf)
-            return hasher.hexdigest()
-        while len(buf) > 0:
+        else:
             # Calculate MD5 checksum of entire file
-            hasher.update(buf)
-            buf = fh.read(blocksize)
+            while len(buf) > 0:
+                hasher.update(buf)
+                buf = fh.read(blocksize)
 
     return hasher.hexdigest()
 
@@ -166,10 +166,9 @@ def standard_input(parser, path, *args, **kwargs):
         # Standard input provided, set path as an
         # empty string to prevent searching of '-'
         path = ""
-        return path
-
-    # Checks for positional arguments as paths
-    path = permissions(parser, path, *args, **kwargs)
+    else:
+        # Checks for positional arguments as paths
+        path = permissions(parser, path, *args, **kwargs)
 
     return path
 
@@ -216,13 +215,14 @@ def which(cmd, path=None):
     if path is None:
         path = os.environ["PATH"].split(os.pathsep)
 
+    found = False
     for prefix in path:
         filename = os.path.join(prefix, cmd)
         executable = os.access(filename, os.X_OK)
         is_not_directory = os.path.isfile(filename)
         if executable and is_not_directory:
-            return True
-    return False
+            found = True
+    return found
 
 
 def err(*message, **kwargs):
@@ -465,14 +465,11 @@ def rename(filename):
         "_2.f(ast)?q.gz$": ".R2.fastq.gz",
     }
 
-    if filename.endswith(".R1.fastq.gz") or filename.endswith(".R2.fastq.gz"):
-        # Filename is already in the correct format
-        return filename
-
-    converted = False
+    converted = filename.endswith(".R1.fastq.gz") or filename.endswith(".R2.fastq.gz")
+    renamed_filename = filename
     for regex, new_ext in extensions.items():
-        matched = re.search(regex, filename)
-        if matched:
+        matched = re.search(regex, renamed_filename)
+        if matched and not converted:
             # regex matches with a pattern in extensions
             converted = True
             # Try to get substring for named group lane, retain this in new file extension
@@ -484,8 +481,7 @@ def rename(filename):
             except IndexError:
                 pass  # Does not contain the named group lane
 
-            filename = re.sub(regex, new_ext, filename)
-            break  # only rename once
+            renamed_filename = re.sub(regex, new_ext, renamed_filename)
 
     if not converted:
         raise NameError(
@@ -501,7 +497,7 @@ def rename(filename):
         """.format(filename)
         )
 
-    return filename
+    return renamed_filename
 
 
 def copy_config(
@@ -545,6 +541,8 @@ def read_config_yml(file):
 
 
 def update_config(config, overwrite_config):
+    """Update config."""
+
     def _update(d, u):
         for key, value in u.items():
             if isinstance(value, collections.abc.Mapping):

--- a/src/ccbr_tools/pkg_util.py
+++ b/src/ccbr_tools/pkg_util.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 
 class CustomClickGroup(click.Group):
     def format_epilog(self, ctx, formatter):
+        """Format the Click epilog text."""
         if self.epilog:
             formatter.write_paragraph()
             for line in self.epilog.split("\n"):
@@ -56,7 +57,8 @@ def get_version(repo_base=repo_base, debug=False):
     if debug:
         print("VERSION file path:", version_path)
     with open(version_path, "r") as infile:
-        return infile.read().strip().lstrip("v")
+        version = infile.read().strip().lstrip("v")
+    return version
 
 
 def get_package_version(pkg_name="ccbr_tools"):
@@ -187,8 +189,10 @@ def get_url_json(url):
 
 
 def get_random_string():
+    """Return a random string."""
     return str(uuid.uuid4()).split("-")[-1]
 
 
 def get_timestamp():
+    """Return the current timestamp."""
     return datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")

--- a/src/ccbr_tools/send_email.py
+++ b/src/ccbr_tools/send_email.py
@@ -36,6 +36,7 @@ def send_email_msg(
     msg["Subject"] = subject
     msg["From"] = from_addr
     msg["To"] = to_address
+    result = None
 
     if text:
         msg.set_content(text)
@@ -49,7 +50,8 @@ def send_email_msg(
             subtype="html",
         )
     if debug:
-        return msg
+        result = msg
     else:
         with smtplib.SMTP("localhost") as server:
             server.send_message(msg)
+    return result

--- a/src/ccbr_tools/shell.py
+++ b/src/ccbr_tools/shell.py
@@ -86,4 +86,5 @@ def concat_newline(*args: str):
 
 
 def get_groups():
+    """Return the current user group names."""
     return shell_run("groups").strip()

--- a/src/ccbr_tools/software.py
+++ b/src/ccbr_tools/software.py
@@ -6,6 +6,7 @@ from .versions import match_semver, get_major_minor_version
 class Software:
     @staticmethod
     def create_software(tool_name, version, software_type=None):
+        """Create a software object for the requested tool."""
         tool_lower = tool_name.lower()
 
         if software_type:
@@ -29,48 +30,58 @@ class Software:
         return f"{self.__class__.__name__}({self.name}, {self.version})"
 
     def path(self, hpc: Cluster):
+        """Return the installation path."""
         hidden_dir = self.hidden_version
         return hpc.TOOLS_HOME / self.name / hidden_dir
 
     def base_path(self, hpc: Cluster):
+        """Return the base installation path."""
         return hpc.TOOLS_HOME / self.name
 
     @property
     def version_re(self):
+        """Return the semantic-version match."""
         return match_semver(self.version, with_leading_v=True)
 
     @property
     def major_minor(self):
+        """Return the major and minor version."""
         version_mm = get_major_minor_version(self.version, with_leading_v=True)
         assert version_mm
         return version_mm
 
     @property
     def hidden_version(self):
+        """Return the hidden version directory name."""
         return f".{self.version}"
 
     @property
     def is_dev_version(self):
+        """Return whether the version is a development release."""
         return self.version_re.group("prerelease") or self.version_re.group(
             "buildmetadata"
         )
 
     @property
     def url(self):
+        """Return the repository URL."""
         return f"https://github.com/CCBR/{self.name}.git"
 
     def install(self, hpc: Cluster, branch_tag=None):
+        """Return the install command."""
         raise NotImplementedError("Subclasses should implement this method")
 
 
 class Installer:
     @staticmethod
     def python(software: Software, hpc: Cluster, branch_tag=None):
+        """Return the Python install command."""
         tag = software.version if not branch_tag else branch_tag
         return f"pip install git+{software.url}@{tag} -t {software.path(hpc)}"
 
     @staticmethod
     def bash(software: Software, hpc: Cluster, branch_tag=None):
+        """Return the Bash install command."""
         tag = software.version if not branch_tag else branch_tag
         return f"git clone --depth 1 --single-branch --branch {tag} {software.url} {software.path(hpc)}"
 
@@ -81,10 +92,12 @@ class PythonTool(Software):
         self.repo_name = name.replace("ccbr_", "")
 
     def install(self, hpc: Cluster, branch_tag=None):
+        """Return the install command."""
         return Installer.python(self, hpc, branch_tag=branch_tag)
 
     @property
     def url(self):
+        """Return the repository URL."""
         return f"https://github.com/CCBR/{self.repo_name}.git"
 
 
@@ -93,6 +106,7 @@ class BashTool(Software):
         super(BashTool, self).__init__(name, version)
 
     def install(self, hpc: Cluster, branch_tag=None):
+        """Return the install command."""
         return Installer.bash(self, hpc, branch_tag=branch_tag)
 
 
@@ -101,13 +115,16 @@ class Nextflow(Software):
         super(Nextflow, self).__init__(name.upper(), version)
 
     def path(self, hpc: Cluster):
+        """Return the installation path."""
         hidden_dir = self.hidden_version
         return hpc.PIPELINES_HOME / self.name / hidden_dir
 
     def base_path(self, hpc: Cluster):
+        """Return the base installation path."""
         return hpc.PIPELINES_HOME / self.name
 
     def install(self, hpc: Cluster, branch_tag=None):
+        """Return the install command."""
         return Installer.python(self, hpc, branch_tag=branch_tag)
 
 
@@ -116,13 +133,16 @@ class Snakemake(Software):
         super(Snakemake, self).__init__(name.upper(), version)
 
     def path(self, hpc: Cluster):
+        """Return the installation path."""
         hidden_dir = self.hidden_version
         return hpc.PIPELINES_HOME / self.name / hidden_dir
 
     def base_path(self, hpc: Cluster):
+        """Return the base installation path."""
         return hpc.PIPELINES_HOME / self.name
 
     def install(self, hpc: Cluster, branch_tag=None):
+        """Return the install command."""
         return Installer.bash(self, hpc, branch_tag=branch_tag)
 
 
@@ -176,6 +196,7 @@ def install(
     final_permissions_script=FINAL_PERMISSIONS,
     debug=False,
 ):
+    """Return the install command."""
     hpc = Cluster.create_hpc(debug=debug)
     tool = Software.create_software(tool_name, version, software_type=software_type)
 

--- a/src/ccbr_tools/spooker.py
+++ b/src/ccbr_tools/spooker.py
@@ -186,6 +186,7 @@ def get_spooker_dict(
 
 
 def main():
+    """Run the CLI."""
     cli()
 
 

--- a/src/ccbr_tools/templates/__init__.py
+++ b/src/ccbr_tools/templates/__init__.py
@@ -51,7 +51,8 @@ def read_template(template_name):
     template_files = importlib.resources.files(__package__)
     template_path = template_files / template_name
     with open(template_path, "rt") as template_file:
-        return template_file.read()
+        template = template_file.read()
+    return template
 
 
 def use_template(template_name, output_filepath=None, **kwargs: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,11 @@ import pytest
 
 @pytest.fixture
 def data_dir():
+    """Return the absolute path to the test data directory."""
     return pathlib.Path(__file__).resolve().parent / "data"
 
 
 @pytest.fixture
 def data_dir_rel():
+    """Return the relative path to the test data directory."""
     return pathlib.Path("tests") / "data"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,39 +10,47 @@ is_ci = (
 
 
 def test_version_flag():
+    """Test version flag."""
     version = shell_run("ccbr_tools --version")
     assert version.startswith("ccbr_tools, version ")
 
 
 @pytest.mark.skipif(is_ci, reason="Skip on CI")
 def test_version_cmd():
+    """Test version cmd."""
     version = shell_run("ccbr_tools version --debug")
     assert version.startswith("VERSION file path")
 
 
 def test_help():
+    """Test help."""
     assert "Utilities for CCBR Bioinformatics Software" in shell_run("ccbr_tools -h")
 
 
 def test_help_cite():
+    """Test help cite."""
     assert "Print the citation in the desired format" in shell_run("ccbr_tools cite -h")
 
 
 def test_help_gb2gtf():
+    """Test help gb2gtf."""
     assert "Usage: gb2gtf sequence.gb > sequence.gtf" in shell_run("gb2gtf -h")
 
 
 def test_help_hf():
+    """Test help hf."""
     assert "Get Human2Mouse (or Mouse2Human) homolog gene or genelist" in shell_run(
         "hf -h"
     )
 
 
 def test_help_jobby():
+    """Test help jobby."""
     assert "jobby <jobid1> [jobid2 ...] " in shell_run("jobby -h")
 
 
 def test_help_jobinfo():
+    """Test help jobinfo."""
     jobinfo_help = shell_run("jobinfo -h")
     assert (
         "Get HPC usage metadata for a list of slurm jobids on biowulf" in jobinfo_help
@@ -50,27 +58,32 @@ def test_help_jobinfo():
 
 
 def test_help_intersect():
+    """Test help intersect."""
     assert "intersect filename1 filename2 f1ColumnIndex F2ColumnIndex" in shell_run(
         "intersect -h"
     )
 
 
 def test_help_peek():
+    """Test help peek."""
     assert "USAGE: peek <file.tsv> [buffer]" in shell_run("peek -h")
 
 
 @pytest.mark.skipif(is_ci, reason="Skip on CI")
 def test_send_email():
+    """Test send email."""
     assert "" == shell_run("ccbr_tools send-email -d")
 
 
 def test_help_send_email():
+    """Test help send email."""
     assert "Usage: ccbr_tools send-email [OPTIONS] [TO_ADDRESS] [TEXT]" in shell_run(
         "ccbr_tools send-email -h"
     )
 
 
 def test_quarto_add(tmp_path):
+    """Test quarto add."""
     current_wd = pathlib.Path.cwd()
     try:
         os.chdir(tmp_path)
@@ -83,6 +96,7 @@ def test_quarto_add(tmp_path):
 
 
 def test_install():
+    """Test install."""
     output = shell_run("ccbr_tools install champagne v0.3.0 --hpc biowulf", check=False)
     assert "mamba activate /" in output
     assert "pip install git+https://github.com/CCBR/CHAMPAGNE.git@v0.3.0" in output

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -4,6 +4,7 @@ import ccbr_tools.__main__ as main_mod
 
 
 def test_cli_version_command(mocker):
+    """Test cli version command."""
     runner = CliRunner()
     mock_get_version = mocker.patch.object(
         main_mod, "get_version", return_value="1.2.3"
@@ -17,6 +18,7 @@ def test_cli_version_command(mocker):
 
 
 def test_cli_cite_command(mocker, tmp_path):
+    """Test cli cite command."""
     runner = CliRunner()
     citation_file = tmp_path / "CITATION.cff"
     citation_file.write_text("cff-version: 1.2.0\nmessage: test\n", encoding="utf-8")
@@ -32,6 +34,7 @@ def test_cli_cite_command(mocker, tmp_path):
 
 
 def test_cli_send_email_command(mocker):
+    """Test cli send email command."""
     runner = CliRunner()
     mock_send_email = mocker.patch.object(main_mod, "send_email_msg")
 
@@ -56,6 +59,7 @@ def test_cli_send_email_command(mocker):
 
 
 def test_cli_quarto_add_command(mocker):
+    """Test cli quarto add command."""
     runner = CliRunner()
     mock_use_quarto_ext = mocker.patch.object(main_mod, "use_quarto_ext")
 
@@ -66,6 +70,7 @@ def test_cli_quarto_add_command(mocker):
 
 
 def test_cli_install_command(mocker):
+    """Test cli install command."""
     runner = CliRunner()
     mock_install = mocker.patch.object(main_mod, "install_software")
 

--- a/tests/test_gb2gtf.py
+++ b/tests/test_gb2gtf.py
@@ -5,6 +5,7 @@ from ccbr_tools.shell import exec_in_context
 
 
 def test_check_args():
+    """Test check args."""
     test_cases = [
         (["", "test"], True),
         (["test"], False),
@@ -17,12 +18,14 @@ def test_check_args():
 
 
 def test_gb2gtf_err(data_dir_rel):
+    """Test gb2gtf err."""
     with pytest.raises(SystemExit) as exc_info:
         gb2gtf.gb2gtf(["", str(data_dir_rel / "sequence_U49845.gb")])
     assert str(exc_info.value) == "Something fishy!"
 
 
 def test_gb2gtf(data_dir_rel):
+    """Test gb2gtf."""
     out = exec_in_context(
         gb2gtf.gb2gtf, ["", str(data_dir_rel / "sequence_AF165912.gb")]
     )

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3,6 +3,7 @@ import pytest
 
 
 def test_print_contributor_images():
+    """Test print contributor images."""
     assert not print_contributor_images(repo="actions", org="CCBR")
 
 

--- a/tests/test_gsea.py
+++ b/tests/test_gsea.py
@@ -7,44 +7,53 @@ import ccbr_tools.GSEA.ncbr_huse as ncbr_huse
 
 
 def test_help_deg():
+    """Test help deg."""
     assert shell_run(f"{sys.executable} -m ccbr_tools.GSEA.deg2gs -h").startswith(
         "usage: deg2gs.py"
     )
 
 
 def test_help_mt2excel():
+    """Test help mt2excel."""
     assert shell_run(
         f"{sys.executable} -m ccbr_tools.GSEA.multitext2excel -h"
     ).startswith("usage: multitext2excel.py")
 
 
 def test_run_cmd():
+    """Test run cmd."""
     assert not ncbr_huse.run_cmd(["echo", "hello"], sys.stdout, True)
 
 
 def test_run_os_cmd():
+    """Test run os cmd."""
     assert not ncbr_huse.run_os_cmd(["echo", "hello"], sys.stdout, True)
 
 
 def test_un_gzip(data_dir_rel):
+    """Test un gzip."""
     assert not ncbr_huse.un_gzip(str(data_dir_rel / "file.txt"), sys.stdout)
 
 
 def test_send_update():
+    """Test send update."""
     assert ncbr_huse.send_update("hello world", log=sys.stderr, quiet=False) == 0
 
 
 def test_err_out():
+    """Test err out."""
     with pytest.raises(SystemExit) as exc_info:
         ncbr_huse.err_out("custom error", log=sys.stderr)
     assert str(exc_info.value) == "custom error"
 
 
 def test_fasta_count(data_dir_rel):
+    """Test fasta count."""
     assert ncbr_huse.fasta_count(str(data_dir_rel / "file.fa")) == 2
     assert ncbr_huse.fasta_count(str(data_dir_rel / "file.txt")) == 0
 
 
 def test_fasta_list(data_dir_rel):
+    """Test fasta list."""
     assert ncbr_huse.fasta_list(str(data_dir_rel / "file.fa")) == ["a", "b"]
     assert ncbr_huse.fasta_list(str(data_dir_rel / "file.txt")) == []

--- a/tests/test_gsea_cli.py
+++ b/tests/test_gsea_cli.py
@@ -8,6 +8,7 @@ import ccbr_tools.GSEA.multitext2excel as mt2excel
 
 
 def test_deg2gs_gsea_pipeliner(tmp_path, mocker):
+    """Test deg2gs gsea pipeliner."""
     df = pd.DataFrame(
         {
             "gene": ["GeneA", "GeneB", "GeneC"],
@@ -62,6 +63,7 @@ def test_deg2gs_gsea_pipeliner(tmp_path, mocker):
 
 
 def test_deg2gs_toppfun_top_table(tmp_path, mocker):
+    """Test deg2gs toppfun top table."""
     df = pd.DataFrame(
         {
             "log2FC": [1.5, 2.5],
@@ -114,6 +116,7 @@ def test_deg2gs_toppfun_top_table(tmp_path, mocker):
 
 
 def test_multitext2excel_writes_sheets(tmp_path, mocker):
+    """Test multitext2excel writes sheets."""
     pytest.importorskip("openpyxl")
 
     input_dir = tmp_path / "inputs"

--- a/tests/test_homologfinder.py
+++ b/tests/test_homologfinder.py
@@ -5,23 +5,27 @@ from ccbr_tools.shell import shell_run
 
 
 def test_hf_gene():
+    """Test hf gene."""
     assert hf.hf(argparse.Namespace(gene="ZNF365", genelist="", genelistfile="")) == [
         "Zfp365"
     ]
 
 
 def test_hf_list():
+    """Test hf list."""
     assert hf.hf(
         argparse.Namespace(gene="", genelist="Wdr53,Zfp365", genelistfile="")
     ) == ["WDR53", "ZNF365"]
 
 
 def test_hf_file():
+    """Test hf file."""
     assert hf.hf(
         argparse.Namespace(gene="", genelist="", genelistfile="tests/data/genelist.txt")
     ) == ["WDR53", "ZNF365"]
 
 
 def test_hf_cli_err():
+    """Test hf cli err."""
     out = shell_run("hf -g a -l b -f c")
     assert "Only one can be provided -g or -l or -f" in out

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -17,6 +17,7 @@ from ccbr_tools.hooks.sync_nextflow_version import (
 
 def test_word_is_absolute_path():
     # Basic absolute paths
+    """Test word is absolute path."""
     assert hooks.word_is_absolute_path("/tmp/file")
     assert hooks.word_is_absolute_path("/usr/local/bin")
     assert hooks.word_is_absolute_path("/home/user/data")
@@ -47,6 +48,7 @@ def test_word_is_absolute_path():
 
 
 def test_line_contains_absolute_path():
+    """Test line contains absolute path."""
     assert hooks.line_contains_absolute_path("/tmp/file")
     assert not hooks.line_contains_absolute_path("relative/path")
 
@@ -60,11 +62,13 @@ def test_line_contains_absolute_path():
 
 
 def test_line_contains_ignore():
+    """Test line contains ignore."""
     assert hooks.line_contains_ignore("value # abs-path:ignore")
     assert not hooks.line_contains_ignore("no ignore tag")
 
 
 def test_file_contains_absolute_path_reports(tmp_path, capsys):
+    """Test file contains absolute path reports."""
     target = tmp_path / "sample.txt"
     target.write_text("/tmp/file\n", encoding="utf-8")
 
@@ -75,6 +79,7 @@ def test_file_contains_absolute_path_reports(tmp_path, capsys):
 
 
 def test_file_contains_absolute_path_ignores_tag(tmp_path, capsys):
+    """Test file contains absolute path ignores tag."""
     target = tmp_path / "sample.txt"
     target.write_text("/tmp/file # abs-path:ignore\n", encoding="utf-8")
 
@@ -85,6 +90,7 @@ def test_file_contains_absolute_path_ignores_tag(tmp_path, capsys):
 
 
 def test_raise_error_if_abs_paths_detected(tmp_path):
+    """Test raise error if abs paths detected."""
     with_abs = tmp_path / "with_abs.txt"
     with_abs.write_text("/tmp/file\n", encoding="utf-8")
 
@@ -98,6 +104,7 @@ def test_raise_error_if_abs_paths_detected(tmp_path):
 
 
 def test_detect_absolute_paths_cli(tmp_path):
+    """Test detect absolute paths cli."""
     runner = CliRunner()
 
     with_abs = tmp_path / "with_abs.txt"
@@ -116,16 +123,19 @@ def test_detect_absolute_paths_cli(tmp_path):
 
 
 def test_detect_absolute_paths_lscratch_line():
+    """Test detect absolute paths lscratch line."""
     target = Path(__file__).resolve().parent / "data" / "hooks" / "abs-path.txt"
     assert hooks.file_contains_absolute_path(target)
 
 
 def test_load_ignored_paths_returns_empty_for_none():
+    """Test load ignored paths returns empty for none."""
     result = hooks.load_ignored_paths(None)
     assert result == []
 
 
 def test_load_ignored_paths_loads_patterns(tmp_path):
+    """Test load ignored paths loads patterns."""
     ignore_file = tmp_path / "ignore.txt"
     ignore_file.write_text(
         "# This is a comment\n"
@@ -148,6 +158,7 @@ def test_load_ignored_paths_loads_patterns(tmp_path):
 
 def test_raise_error_if_abs_paths_detected_with_ignored_patterns(tmp_path):
     # Create test files
+    """Test raise error if abs paths detected with ignored patterns."""
     file1 = tmp_path / "file1.log"
     file1.write_text("/tmp/file\n", encoding="utf-8")
 
@@ -173,6 +184,7 @@ def test_raise_error_if_abs_paths_detected_with_ignored_patterns(tmp_path):
 
 def test_raise_error_if_abs_paths_detected_with_directory_pattern(tmp_path):
     # Create nested structure
+    """Test raise error if abs paths detected with directory pattern."""
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     build_file = build_dir / "output.txt"
@@ -198,6 +210,7 @@ def test_raise_error_if_abs_paths_detected_with_directory_pattern(tmp_path):
 
 def test_raise_error_if_abs_paths_detected_with_glob_patterns(tmp_path):
     # Create test files
+    """Test raise error if abs paths detected with glob patterns."""
     test1 = tmp_path / "test_foo.py"
     test1.write_text("/tmp/file\n", encoding="utf-8")
 
@@ -225,6 +238,7 @@ def test_raise_error_if_abs_paths_detected_with_glob_patterns(tmp_path):
 
 
 def test_detect_absolute_paths_cli_with_ignore_paths_file(tmp_path):
+    """Test detect absolute paths cli with ignore paths file."""
     runner = CliRunner()
 
     # Create test files
@@ -260,6 +274,7 @@ def test_detect_absolute_paths_cli_with_ignore_paths_file(tmp_path):
 
 
 def test_detect_absolute_paths_cli_with_ignore_paths_option(tmp_path):
+    """Test detect absolute paths cli with ignore paths option."""
     runner = CliRunner()
 
     # Create test files
@@ -306,6 +321,7 @@ def test_detect_absolute_paths_cli_with_ignore_paths_option(tmp_path):
 
 
 def test_detect_absolute_paths_cli_with_both_file_and_cli_patterns(tmp_path):
+    """Test detect absolute paths cli with both file and cli patterns."""
     runner = CliRunner()
 
     # Create test files
@@ -471,6 +487,7 @@ def test_ignore_paths_only_file_no_cli(tmp_path):
 
 
 def test_update_manifest_version_updates_manifest_entry():
+    """Test update manifest version updates manifest entry."""
     config_text = """
 manifest {
     name = "CCBR/example"
@@ -485,6 +502,7 @@ manifest {
 
 
 def test_update_manifest_version_preserves_existing_value():
+    """Test update manifest version preserves existing value."""
     config_text = """
 manifest {
     version = "1.2.3"
@@ -498,6 +516,7 @@ manifest {
 
 
 def test_update_manifest_version_raises_when_manifest_version_missing():
+    """Test update manifest version raises when manifest version missing."""
     config_text = """
 manifest {
     name = "CCBR/example"
@@ -509,6 +528,7 @@ manifest {
 
 
 def test_sync_nextflow_version_cli_updates_repo_root_file(tmp_path):
+    """Test sync nextflow version cli updates repo root file."""
     runner = CliRunner()
     version_file = tmp_path / "VERSION"
     version_file.write_text("1.2.3\n", encoding="utf-8")
@@ -540,6 +560,7 @@ manifest {
 
 
 def test_sync_nextflow_version_cli_skips_when_nextflow_config_missing(tmp_path):
+    """Test sync nextflow version cli skips when nextflow config missing."""
     runner = CliRunner()
 
     with runner.isolated_filesystem(temp_dir=str(tmp_path)):
@@ -551,6 +572,7 @@ def test_sync_nextflow_version_cli_skips_when_nextflow_config_missing(tmp_path):
 
 
 def test_sync_nextflow_version_cli_fails_when_version_missing(tmp_path):
+    """Test sync nextflow version cli fails when version missing."""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=str(tmp_path)):
         Path("nextflow.config").write_text(
@@ -568,6 +590,7 @@ manifest {
 
 
 def test_sync_nextflow_version_cli_propagates_manifest_version_error(tmp_path):
+    """Test sync nextflow version cli propagates manifest version error."""
     runner = CliRunner()
 
     with runner.isolated_filesystem(temp_dir=str(tmp_path)):
@@ -587,6 +610,7 @@ manifest {
 
 
 def test_sync_nextflow_version_cli_skips_write_when_version_is_current(tmp_path):
+    """Test sync nextflow version cli skips write when version is current."""
     runner = CliRunner()
 
     with runner.isolated_filesystem(temp_dir=str(tmp_path)) as cwd:
@@ -605,6 +629,7 @@ manifest {
 
 
 def test_file_is_text_with_unknown_extension(tmp_path):
+    """Test file is text with unknown extension."""
     target = tmp_path / "notes.unknown"
     target.write_text("/tmp/file\n", encoding="utf-8")
 
@@ -612,6 +637,7 @@ def test_file_is_text_with_unknown_extension(tmp_path):
 
 
 def test_file_contains_absolute_path_skips_non_text(tmp_path, capsys):
+    """Test file contains absolute path skips non text."""
     target = tmp_path / "image.png"
     target.write_bytes(b"/tmp/file\n")
 
@@ -622,6 +648,7 @@ def test_file_contains_absolute_path_skips_non_text(tmp_path, capsys):
 
 
 def test_hooks_cli_help():
+    """Test hooks cli help."""
     runner = CliRunner()
 
     result = runner.invoke(hooks_main.cli, ["--help"])
@@ -632,10 +659,12 @@ def test_hooks_cli_help():
 
 
 def test_hooks_cli_callback_smoke():
+    """Test hooks cli callback smoke."""
     assert hooks_main.cli.callback() is None
 
 
 def test_hooks_main_invokes_cli(mocker):
+    """Test hooks main invokes cli."""
     mock_cli = mocker.patch.object(hooks_main, "cli")
 
     hooks_main.main()
@@ -644,6 +673,7 @@ def test_hooks_main_invokes_cli(mocker):
 
 
 def test_hooks_main_module_entrypoint(monkeypatch):
+    """Test hooks main module entrypoint."""
     monkeypatch.setattr(sys, "argv", ["ccbr-hooks", "--help"])
     sys.modules.pop("ccbr_tools.hooks.__main__", None)
 
@@ -654,6 +684,7 @@ def test_hooks_main_module_entrypoint(monkeypatch):
 
 
 def test_pre_commit_try_repo_detect_absolute_paths(tmp_path):
+    """Test pre commit try repo detect absolute paths."""
     if shutil.which("pre-commit") is None:
         pytest.skip("pre-commit is not installed")
 
@@ -700,6 +731,7 @@ def test_pre_commit_try_repo_detect_absolute_paths(tmp_path):
 
 
 def test_detect_absolute_paths_module_entrypoint(monkeypatch):
+    """Test detect absolute paths module entrypoint."""
     monkeypatch.setattr(sys, "argv", ["detect-absolute-paths"])
 
     try:

--- a/tests/test_intersect.py
+++ b/tests/test_intersect.py
@@ -4,6 +4,7 @@ from ccbr_tools.shell import exec_in_context
 
 
 def test_intersect(data_dir_rel):
+    """Test intersect."""
     out = exec_in_context(
         ccbr_tools.intersect.run_intersect,
         [
@@ -18,6 +19,7 @@ def test_intersect(data_dir_rel):
 
 
 def test_intersect_err(data_dir_rel):
+    """Test intersect err."""
     with pytest.raises(IndexError) as exc_info:
         exec_in_context(
             ccbr_tools.intersect.run_intersect,
@@ -33,6 +35,7 @@ def test_intersect_err(data_dir_rel):
 
 
 def test_intersect_help(data_dir_rel):
+    """Test intersect help."""
     out = exec_in_context(
         ccbr_tools.intersect.run_intersect,
         [
@@ -48,6 +51,7 @@ def test_intersect_help(data_dir_rel):
 
 
 def test_intersect_usage():
+    """Test intersect usage."""
     with pytest.raises(SystemExit):
         out = exec_in_context(ccbr_tools.intersect.run_intersect, [])
         assert out.startswith("INCORRECT USAGE:")

--- a/tests/test_jobby.py
+++ b/tests/test_jobby.py
@@ -93,6 +93,7 @@ def generate_df():
 
 
 def test_jobby_cli_version():
+    """Test jobby cli version."""
     output = shell_run("jobby --version")
     this_version = shell_run("ccbr_tools --version").split()[-1]
     assert output.startswith("jobby: ccbr_tools version: ")
@@ -100,6 +101,7 @@ def test_jobby_cli_version():
 
 
 def test_jobby_cli_invalid():
+    """Test jobby cli invalid."""
     err_msg = (
         "sacct: fatal: Bad job/step specified: tests/data/jobby/invalid.log"
         if HPC == "biowulf"
@@ -115,6 +117,7 @@ def test_jobby_cli_invalid():
 
 
 def test_jobby_no_list():
+    """Test jobby no list."""
     with pytest.raises(TypeError) as exc_info:
         jobby("50456412")
     assert "Expected a list of arguments" in str(exc_info.value)
@@ -122,6 +125,7 @@ def test_jobby_no_list():
 
 @pytest.mark.skipif(HPC != "", reason="HPC is not empty")
 def test_jobby_no_args():
+    """Test jobby no args."""
     with pytest.warns(UserWarning) as exc_info:
         jobby([])
     assert "No job IDs to process" in str(exc_info[0].message)
@@ -129,6 +133,7 @@ def test_jobby_no_args():
 
 @pytest.mark.skipif(HPC != "", reason="HPC is not empty")
 def test_jobby_no_records():
+    """Test jobby no records."""
     with pytest.raises(RuntimeError) as exc_info:
         jobby(["invalid_job_id"])
     assert "sacct command not found" in str(exc_info.value)
@@ -136,6 +141,7 @@ def test_jobby_no_records():
 
 @pytest.mark.skipif(HPC != "biowulf", reason="only works on biowulf")
 def test_jobby_no_records_biowulf():
+    """Test jobby no records biowulf."""
     with pytest.warns(UserWarning) as exc_info:
         jobby(["invalid_job_id"])
     assert "Failed to fetch info for JobID" in str(exc_info[0].message)
@@ -146,6 +152,7 @@ def test_jobby_no_records_biowulf():
     reason="only works for sovacoolkl on biowulf",
 )
 def test_jobby_biowulf():
+    """Test jobby biowulf."""
     jobby_out = jobby(["50456412"])
     pprint.pprint(jobby_out)
     assert jobby_out == [
@@ -176,6 +183,7 @@ def test_jobby_biowulf():
 
 
 def test_parse_time_to_seconds():
+    """Test parse time to seconds."""
     results = [
         parse_time_to_seconds(t) == expected
         for t, expected in [
@@ -195,6 +203,7 @@ def test_parse_time_to_seconds():
 
 
 def test_parse_mem_to_gb():
+    """Test parse mem to gb."""
     results = [
         parse_mem_to_gb(mem_str) == expected
         for mem_str, expected in [
@@ -214,6 +223,7 @@ def test_parse_mem_to_gb():
 
 
 def test_assertions():
+    """Test assertions."""
     with pytest.raises(AssertionError) as exc1:
         parse_time_to_seconds(False)
     with pytest.raises(AssertionError) as exc2:
@@ -223,6 +233,7 @@ def test_assertions():
 
 
 def test_extract_jobids_snakemake():
+    """Test extract jobids snakemake."""
     assert extract_jobids_from_file("tests/data/jobby/snakemake.log") == [
         "50456412",
         "50456444",
@@ -254,6 +265,7 @@ def test_extract_jobids_snakemake():
 
 
 def test_extract_jobids_nextflow():
+    """Test extract jobids nextflow."""
     assert extract_jobids_from_file("tests/data/jobby/nextflow.log") == [
         "55256481",
         "55256959",
@@ -269,12 +281,14 @@ def test_extract_jobids_nextflow():
 
 @pytest.mark.filterwarnings("ignore:File not found")
 def test_extract_jobids_empty():
+    """Test extract jobids empty."""
     with pytest.warns(UserWarning):
         output = extract_jobids_from_file("not_a_file")
     assert output == []
 
 
 def test_records_to_df_smk():
+    """Test records to df smk."""
     with open("tests/data/jobby/records_smk.pkl", "rb") as f:
         records_smk = pickle.load(f)
     with open("tests/data/jobby/df_smk.pkl", "rb") as f:
@@ -288,6 +302,7 @@ def test_records_to_df_smk():
 
 
 def test_records_to_df_nxf():
+    """Test records to df nxf."""
     with open("tests/data/jobby/records_nxf.pkl", "rb") as f:
         records_nxf = pickle.load(f)
     with open("tests/data/jobby/df_nxf.pkl", "rb") as f:
@@ -301,6 +316,7 @@ def test_records_to_df_nxf():
 
 
 def test_format_df():
+    """Test format df."""
     with open("tests/data/jobby/df_smk.pkl", "rb") as f:
         df_smk = pickle.load(f)
     assertions = []
@@ -323,6 +339,7 @@ def test_format_df():
 
 
 def test_get_job_logs():
+    """Test get job logs."""
     assert get_job_logs("abc", "tests/data/pipeline/work") == {
         "log_out_path": "tests/data/pipeline/work/.command.out",
         "log_out_txt": "",

--- a/tests/test_jobinfo.py
+++ b/tests/test_jobinfo.py
@@ -8,23 +8,27 @@ from ccbr_tools.jobinfo import get_jobinfo, check_host, mem2gb, time2sec
 
 
 def test_jobinfo_cli():
+    """Test jobinfo cli."""
     out = shell_run(f"{sys.executable} -m ccbr_tools.jobinfo -j 123456")
     assert "This script only works on BIOWULF!" in out
 
 
 def test_jobinfo():
+    """Test jobinfo."""
     with pytest.raises(SystemExit) as exc_info:
         get_jobinfo(argparse.Namespace(joblist=["job1", "job2"]))
     assert str(exc_info.value) == "" and type(exc_info.value) is SystemExit
 
 
 def test_check_host():
+    """Test check host."""
     with pytest.raises(SystemExit) as exc_info:
         check_host()
     assert str(exc_info.value) == "" and type(exc_info.value) is SystemExit
 
 
 def test_mem2gb():
+    """Test mem2gb."""
     assert mem2gb("0") == 0.0
     assert mem2gb("3.5 GB") == 3.5
     assert mem2gb("1024 MB") == 1.0
@@ -32,10 +36,12 @@ def test_mem2gb():
 
 
 def test_time2sec():
+    """Test time2sec."""
     assert time2sec("0-00:01:00") == 60.0
 
 
 def test_get_jobinfo_parses_output(mocker, tmp_path):
+    """Test get jobinfo parses output."""
     sample = [
         {
             "jobid": "123",
@@ -76,6 +82,7 @@ def test_get_jobinfo_parses_output(mocker, tmp_path):
             self.stdout = stdout
 
     def fake_run(*_args, **_kwargs):
+        """Mock subprocess.run for testing."""
         return DummyProc(json.dumps(sample))
 
     mocker.patch("ccbr_tools.jobinfo.subprocess.run", side_effect=fake_run)

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -3,12 +3,14 @@ from ccbr_tools.pipeline.hpc import parse_modules, is_loaded
 
 
 def test_module_list_cli():
+    """Test module list cli."""
     assert shell_run("module_list") == "{}\n"
     assert shell_run("module_list not_a_module") == "not_loaded\n"
     assert "Show this help message" in shell_run("module_list -h")
 
 
 def test_parse_modules():
+    """Test parse modules."""
     assert parse_modules(
         "\nCurrently Loaded Modules:\n  1) ccbrpipeliner/7   3) singularity/4.2.2\n  2) java/17.0.3.1     4) nextflow/24.10.3\n\n \n\n"
     ) == {
@@ -21,4 +23,5 @@ def test_parse_modules():
 
 
 def test_is_loaded():
+    """Test is loaded."""
     assert not is_loaded("not_a_module")

--- a/tests/test_nextflow.py
+++ b/tests/test_nextflow.py
@@ -9,6 +9,7 @@ from ccbr_tools.shell import exec_in_context
 
 
 def test_init(tmp_path, data_dir):
+    """Test init."""
     init(
         output=tmp_path,
         repo_base=lambda f: data_dir / "pipeline" / f,
@@ -21,11 +22,13 @@ def test_init(tmp_path, data_dir):
 
 
 def test_nextflow_basic():
+    """Test nextflow basic."""
     output = exec_in_context(run, nextfile_path="CCBR/CHAMPAGNE", debug=True)
     assert "nextflow run CCBR/CHAMPAGNE" in output and "-resume" in output
 
 
 def test_nextflow_forceall():
+    """Test nextflow forceall."""
     output = exec_in_context(
         run, nextfile_path="CCBR/CHAMPAGNE", debug=True, force_all=True
     )
@@ -33,6 +36,7 @@ def test_nextflow_forceall():
 
 
 def test_nextflow_hpc():
+    """Test nextflow hpc."""
     assert "module load nextflow/25 &&" in exec_in_context(
         run,
         nextfile_path="CCBR/CHAMPAGNE",
@@ -46,6 +50,7 @@ def test_nextflow_hpc():
 
 
 def test_nextflow_slurm(tmp_path):
+    """Test nextflow slurm."""
     current_wd = pathlib.Path.cwd()
     try:
         os.chdir(tmp_path)
@@ -62,6 +67,7 @@ def test_nextflow_slurm(tmp_path):
 
 
 def test_nextflow_preview_error(tmp_path, data_dir_rel):
+    """Test nextflow preview error."""
     current_wd = pathlib.Path.cwd()
     try:
         os.chdir(tmp_path)

--- a/tests/test_peek.py
+++ b/tests/test_peek.py
@@ -3,6 +3,7 @@ from ccbr_tools.shell import exec_in_context
 
 
 def test_peek(data_dir_rel):
+    """Test peek."""
     filepath = data_dir_rel / "tab.tsv"
     out = exec_in_context(peek.peek, str(filepath), 40)
     assert str(filepath) in out

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -9,16 +9,19 @@ from ccbr_tools.pipeline.cache import (
 
 
 def test_get_sif_cache_dir():
+    """Test get sif cache dir."""
     assert "CCBR_Pipeliner/SIFs" in get_sif_cache_dir("biowulf")
     assert "CCBR-Pipelines/SIFs" in get_sif_cache_dir("frce")
 
 
 def test_get_singularity_cachedir():
+    """Test get singularity cachedir."""
     assert get_singularity_cachedir("outdir") == "outdir/.singularity"
     assert get_singularity_cachedir("outdir", "cache") == "cache"
 
 
 def test_image_cache(data_dir_rel):
+    """Test image cache."""
     d = image_cache(
         argparse.Namespace(
             output=str(data_dir_rel), sif_cache=str(data_dir_rel / "sif")
@@ -30,6 +33,7 @@ def test_image_cache(data_dir_rel):
 
 
 def test_check_cache(tmp_path, data_dir_rel):
+    """Test check cache."""
     sif_dir = tmp_path / "sifs"
     assert check_cache(argparse.Namespace(), sif_dir) == sif_dir
     assert check_cache(argparse.Namespace(), str(data_dir_rel / "sifs")) == str(

--- a/tests/test_pipeline_hpc.py
+++ b/tests/test_pipeline_hpc.py
@@ -6,6 +6,7 @@ from ccbr_tools.shell import shell_run
 
 
 def test_hpc_biowulf():
+    """Test hpc biowulf."""
     hpc = get_hpc(debug="biowulf")
     assert hpc
     assert hpc.name == "biowulf"
@@ -17,6 +18,7 @@ def test_hpc_biowulf():
 
 
 def test_hpc_frce():
+    """Test hpc frce."""
     hpc = get_hpc(debug="frce")
     assert hpc
     assert hpc.name == "frce"
@@ -26,22 +28,26 @@ def test_hpc_frce():
 
 
 def test_hpc_none():
+    """Test hpc none."""
     hpc = get_hpc(debug=" ")
     assert not any([hpc, hpc.name, hpc.singularity_sif_dir])
 
 
 def test_hpcname_type():
+    """Test hpcname type."""
     hpcname = get_hpcname()
     assert isinstance(hpcname, str), "Expected hpcname to be a string"
 
 
 def test_hpcname_expected_values():
+    """Test hpcname expected values."""
     hpcname = get_hpcname().strip().lower()
     if hpcname:
         assert hpcname in ["biowulf", "frce", "helix"], f"Unexpected hpcname: {hpcname}"
 
 
 def test_hpcname_print_output():
+    """Test hpcname print output."""
     captured = io.StringIO()
     sys.stdout = captured
     print(get_hpcname())
@@ -55,6 +61,7 @@ def test_hpcname_print_output():
 
 
 def test_hpcname_cli():
+    """Test hpcname cli."""
     out = shell_run("get_hpcname", shell=True, capture_output=True, text=True).strip()
     assert not out
 

--- a/tests/test_pipeline_util.py
+++ b/tests/test_pipeline_util.py
@@ -16,6 +16,7 @@ from ccbr_tools.pkg_util import repo_base
 
 
 def test_copy_config(tmp_path, data_dir):
+    """Test copy config."""
     copy_config(
         ("file.txt", "file2.txt"),
         repo_base=lambda f: data_dir / f,
@@ -27,33 +28,39 @@ def test_copy_config(tmp_path, data_dir):
 
 
 def test_tmp_dir():
+    """Test tmp dir."""
     assert get_tmp_dir("", "./out", hpc="biowulf").startswith("/lscratch")
     assert get_tmp_dir("", "./out", hpc="frce").startswith("./out")
     assert get_tmp_dir("", "./out", hpc="none") is None
 
 
 def test_get_mtime(data_dir):
+    """Test get mtime."""
     mtime = _get_file_mtime(data_dir / "file.txt")
     assert len(mtime) == 12
     assert mtime.isdigit()
 
 
 def test_get_genomes_dict():
+    """Test get genomes dict."""
     d = get_genomes_dict(repo_base)
     assert d == {}
 
 
 def test_md5sum(data_dir):
+    """Test md5sum."""
     assert md5sum(data_dir / "file.txt") == "47ece2e49e5c0333677fc34e044d8257"
     assert md5sum(data_dir / "file2.txt") == "04ab3457e5e52c208c1af0139ad47d25"
 
 
 def test_permissions(data_dir):
+    """Test permissions."""
     abspath = permissions(argparse.ArgumentParser(), data_dir / "file.txt", os.R_OK)
     assert abspath.endswith("tests/data/file.txt")
 
 
 def test_exists(data_dir):
+    """Test exists."""
     assertions = [
         pathlib.Path(p).exists() == exists(p)
         for p in [data_dir / "file.txt", data_dir / "file2.txt", "not/a/path"]
@@ -64,5 +71,6 @@ def test_exists(data_dir):
 
 
 def test_which():
+    """Test which."""
     assert which("ls")
     assert not which("unknown")

--- a/tests/test_pkg_util.py
+++ b/tests/test_pkg_util.py
@@ -3,10 +3,12 @@ import pytest
 
 
 def test_repo_base():
+    """Test repo base."""
     assert str(repo_base()).endswith("ccbr_tools")
 
 
 def test_get_url_json():
+    """Test get url json."""
     with pytest.raises(ConnectionError) as exc_info:
         url = "https://api.github.com/users/"
         get_url_json(url)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,12 +3,14 @@ from ccbr_tools.pipeline.hpc import get_hpcname
 
 
 def test_scripts_help():
+    """Test scripts help."""
     assert "extract value for key from JSON" in shell_run(
         "extract_value_from_json.py --help"
     )
 
 
 def test_which_vpn():
+    """Test which vpn."""
     which_vpn = shell_run("which_vpn.sh", check=False)
     hpc = get_hpcname()
     if hpc == "biowulf":

--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -2,6 +2,7 @@ from ccbr_tools.send_email import send_email_msg
 
 
 def test_send_email_no_attach():
+    """Test send email no attach."""
     assert {
         "Subject": "test email from python",
         "From": "${USER}@hpc.nih.gov",
@@ -13,6 +14,7 @@ def test_send_email_no_attach():
 
 
 def test_send_email_attach():
+    """Test send email attach."""
     assert {
         "Subject": "test email from python",
         "From": "${USER}@hpc.nih.gov",

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -2,14 +2,17 @@ from ccbr_tools.shell import shell_run, exec_in_context, concat_newline
 
 
 def test_exec():
+    """Test exec."""
     assert exec_in_context(print, "hello", "world") == "hello world\n"
 
 
 def test_shell_run():
+    """Test shell run."""
     assert shell_run("echo hello world") == "hello world\n"
 
 
 def test_concat_newline():
+    """Test concat newline."""
     assert concat_newline("hello", "world") == "hello\nworld"
     assert concat_newline("goodbye", "") == "goodbye"
     assert concat_newline() == ""

--- a/tests/test_software.py
+++ b/tests/test_software.py
@@ -12,6 +12,7 @@ import pytest
 
 
 def test_python():
+    """Test python."""
     assert (
         Software.create_software("ccbr_tools", "v0.3.2").url
         == "https://github.com/CCBR/tools.git"
@@ -29,6 +30,7 @@ def test_python():
 
 
 def test_pipelines():
+    """Test pipelines."""
     assert (
         Software.create_software("CHAMPAGNE", "v0.3.0").install(hpc=Biowulf)
         == "pip install git+https://github.com/CCBR/CHAMPAGNE.git@v0.3.0 -t /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0"
@@ -40,6 +42,7 @@ def test_pipelines():
 
 
 def test_bash():
+    """Test bash."""
     assert (
         Software.create_software("permfix", "v1.2.3").install(Biowulf)
         == "git clone --depth 1 --single-branch --branch v1.2.3 https://github.com/CCBR/permfix.git /data/CCBR_Pipeliner/Tools/permfix/.v1.2.3"
@@ -47,6 +50,7 @@ def test_bash():
 
 
 def test_install():
+    """Test install."""
     result = exec_in_context(
         install, tool_name="CHAMPAGNE", version="v0.3.0", dryrun=True, debug="biowulf"
     )
@@ -67,6 +71,7 @@ chmod -R u-w,g-w,o-w,a+rX /data/CCBR_Pipeliner/Pipelines/CHAMPAGNE/.v0.3.0
 
 
 def test_install_dev():
+    """Test install dev."""
     result = exec_in_context(
         install,
         tool_name="CHAMPAGNE",
@@ -86,6 +91,7 @@ def test_install_dev():
 
 
 def test_custom():
+    """Test custom."""
     result = exec_in_context(
         install,
         tool_name="cooltool",
@@ -111,6 +117,7 @@ chmod -R u-w,g-w,o-w,a+rX /data/CCBR_Pipeliner/Tools/cooltool/.v1.0.0
 
 
 def test_unsupported():
+    """Test unsupported."""
     with pytest.raises(KeyError) as exc_info:
         Software.create_software("unsupported_tool", "v1.0.0")
     assert "unsupported_tool not found in software list" in str(exc_info.value)

--- a/tests/test_spooker.py
+++ b/tests/test_spooker.py
@@ -9,6 +9,7 @@ from ccbr_tools.spooker import spooker
 
 @pytest.mark.filterwarnings("ignore:UserWarning")
 def test_spooker(data_dir_rel):
+    """Test spooker."""
     pipeline_outdir = data_dir_rel / "pipeline_run"
     out_filename = spooker(
         pipeline_outdir=pipeline_outdir,
@@ -36,6 +37,7 @@ def test_spooker(data_dir_rel):
 
 
 def test_spooker_no_outdir(data_dir_rel):
+    """Test spooker no outdir."""
     with pytest.raises(FileNotFoundError) as exc_info:
         spooker(
             pipeline_outdir=data_dir_rel / "pipeline_run" / "does_not_exist",
@@ -49,6 +51,7 @@ def test_spooker_no_outdir(data_dir_rel):
 
 
 def test_spooker_cli(data_dir_rel):
+    """Test spooker cli."""
     pipeline_outdir = data_dir_rel / "pipeline_run"
     out = subprocess.run(
         f"spooker --outdir {pipeline_outdir} --name test_pipeline --version 0.1.2-dev --path unknown --debug gha",
@@ -85,6 +88,7 @@ def test_spooker_cli(data_dir_rel):
 
 
 def test_spooker_help():
+    """Test spooker help."""
     assert (
         "Usage: spooker "
         in subprocess.run(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,12 +7,14 @@ from ccbr_tools.pipeline.hpc import get_hpc
 
 
 def test_read_template():
+    """Test read template."""
     template_str = read_template("submit_slurm.sh")
     assert template_str.startswith("#!/usr/bin/env bash")
     assert template_str.endswith("{RUN_COMMAND}\n")
 
 
 def test_use_template(tmp_path):
+    """Test use template."""
     out_filepath = tmp_path / "test.sh"
     use_template(
         "submit_slurm.sh",
@@ -33,6 +35,7 @@ def test_use_template(tmp_path):
 
 
 def generate_slurm_template():
+    """Generate a sample SLURM template for testing."""
     hpc = get_hpc(debug="biowulf")
     use_template(
         "submit_slurm.sh",
@@ -47,6 +50,7 @@ def generate_slurm_template():
 
 
 def test_use_template_blanks(tmp_path):
+    """Test use template blanks."""
     out_filepath = tmp_path / "test.sh"
     with pytest.raises(KeyError) as exc_info:
         use_template(
@@ -57,6 +61,7 @@ def test_use_template_blanks(tmp_path):
 
 
 def test_use_quarto_ext(tmp_path):
+    """Test use quarto ext."""
     current_wd = pathlib.Path.cwd()
     try:
         os.chdir(tmp_path)
@@ -70,6 +75,7 @@ def test_use_quarto_ext(tmp_path):
 
 
 def test_use_quarto_ext_error():
+    """Test use quarto ext error."""
     with pytest.raises(FileNotFoundError) as exc_info:
         use_quarto_ext("not_a_real_extension")
     assert str(exc_info.value).startswith("not_a_real_extension does not exist")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -13,26 +13,31 @@ from ccbr_tools.versions import (
 
 
 def test_get_releases():
+    """Test get releases."""
     assert match_semver(get_releases(limit=1)[0]["tagName"], with_leading_v=True)
 
 
 def test_get_latest_release_tag():
+    """Test get latest release tag."""
     assert match_semver(get_latest_release_tag(), with_leading_v=True)
 
 
 def test_get_latest_release_hash():
+    """Test get latest release hash."""
     assert len(get_latest_release_hash()) > 7
     assert len(get_latest_release_hash(repo="CCBR/actions")) > 7
     assert get_latest_release_hash(repo="CCBR/CCBR_NextflowTemplate") == ""
 
 
 def test_get_tag_hash():
+    """Test get tag hash."""
     assert len(get_tag_hash("v0.1.0")) > 7
     assert len(get_tag_hash("v0.2.0", repo="CCBR/actions")) > 7
     assert get_tag_hash("notATag", repo="CCBR/CCBR_NextflowTemplate") == ""
 
 
 def test_version_increment():
+    """Test version increment."""
     assert check_version_increments_by_one("v0.1.0", "v0.2.0", with_leading_v=True)
     assert check_version_increments_by_one("0.1.0", "0.1.1", with_leading_v=False)
     assert check_version_increments_by_one(
@@ -41,6 +46,7 @@ def test_version_increment():
 
 
 def test_version_increment_error():
+    """Test version increment error."""
     messages = []
     with pytest.raises(ValueError) as exc_info:
         check_version_increments_by_one("v0.1.0", "v0.2.1", with_leading_v=True)
@@ -73,6 +79,7 @@ def test_version_increment_error():
 
 
 def test_get_major_minor():
+    """Test get major minor."""
     assert get_major_minor_version("1.0.0") == "1.0"
     assert get_major_minor_version("2.1.3-alpha") == "2.1"
     assert get_major_minor_version("v1.0.0", with_leading_v=True) == "v1.0"
@@ -81,6 +88,7 @@ def test_get_major_minor():
 
 
 def test_get_major_minor_nonsemantic():
+    """Test get major minor nonsemantic."""
     assert get_major_minor_version("1.0", strict_semver=False) == "1.0"
     assert (
         get_major_minor_version("v3.4", with_leading_v=True, strict_semver=False)
@@ -90,6 +98,7 @@ def test_get_major_minor_nonsemantic():
 
 
 def test_is_ancestor():
+    """Test is ancestor."""
     assert is_ancestor("v0.1.0", "v0.1.1")
     assert is_ancestor("d620b61", "6cf677a")
     assert is_ancestor("d620b61\n", "\n6cf677a")


### PR DESCRIPTION
## Changes

- Reviewed the new Python coding instructions and updated Python files across the repository to comply with them.
- Added missing public-function docstrings where needed.
- Refactored affected functions to follow the new control-flow requirements, including using a single final `return` where applicable and removing `break` / `continue` usage without changing intended behavior.
- Verified the changes with `pre-commit run --all-files` and targeted pytest coverage for the refactored modules.
- Confirmed full `python -m pytest` still only shows the same pre-existing network-restricted GitHub API failures seen at baseline.

## Issues

- No new functionality was added; this PR now covers both introducing the Python instructions and applying them across the existing Python code.

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~